### PR TITLE
Recipe: Partial Path Traversal Vulnerability

### DIFF
--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -13,6 +13,7 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.util.Collections;
+import java.util.Set;
 
 public class PartialPathTraversalVulnerability extends Recipe {
     private static final MethodMatcher getCanonicalPathMatcher =
@@ -32,6 +33,11 @@ public class PartialPathTraversalVulnerability extends Recipe {
                 "It's important to understand that the terminating slash may be removed when using various `String` representations of the `File` object. " +
                 "For example, on Linux, `println(new File(\"/var\"))` will print `/var`, but `println(new File(\"/var\", \"/\")` will print `/var/`; " +
                 "however, `println(new File(\"/var\", \"/\").getCanonicalPath())` will print `/var`.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("CWE-22");
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -1,0 +1,127 @@
+package org.openrewrite.java.security;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
+
+public class PartialPathTraversalVulnerability extends Recipe {
+    private static final MethodMatcher getCanonicalPathMatcher =
+            new MethodMatcher("java.io.File getCanonicalPath()");
+    private static final MethodMatcher startsWithMatcher =
+            new MethodMatcher("java.lang.String startsWith(java.lang.String)");
+
+    @Override
+    public String getDisplayName() {
+        return "Partial path traversal vulnerability";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visitJavaSourceFile(JavaSourceFile cu, ExecutionContext executionContext) {
+                doAfterVisit(new UsesMethod<>(getCanonicalPathMatcher));
+                doAfterVisit(new UsesMethod<>(startsWithMatcher));
+                return cu;
+            }
+        };
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new PartialPathTraversalVulnerabilityVisitor<>();
+    }
+
+    private static class PartialPathTraversalVulnerabilityVisitor<P> extends JavaIsoVisitor<P> {
+        private static final JavaType.FullyQualified TYPE_FILE =
+                TypeUtils.asFullyQualified(JavaType.buildType("java.io.File"));
+        private static final JavaType.FullyQualified TYPE_PATH =
+                TypeUtils.asFullyQualified(JavaType.buildType("java.io.Path"));
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
+            if (startsWithMatcher.matches(method)) {
+                assert method.getSelect() != null : "Select is null for `startsWith`";
+                final Expression select = unwrap(method.getSelect());
+                final Expression argument = unwrap(method.getArguments().get(0));
+                if (getCanonicalPathMatcher.matches(select) &&
+                        getCanonicalPathMatcher.matches(argument)) {
+                    final J.MethodInvocation getCanonicalPathSubject = (J.MethodInvocation) select;
+                    final J.MethodInvocation getCanonicalPathArgument = (J.MethodInvocation) argument;
+                    final J.MethodInvocation getCanonicalPathSubjectReplacement =
+                            replaceGetCanonicalPath(getCanonicalPathSubject);
+                    final J.MethodInvocation getCanonicalPathArgumentReplacement =
+                            replaceGetCanonicalPath(getCanonicalPathArgument);
+                    return maybeAutoFormat(
+                            method,
+                            method.withSelect(getCanonicalPathSubjectReplacement)
+                                    .withArguments(Collections.singletonList(getCanonicalPathArgumentReplacement))
+                                    .withMethodType(method.getMethodType().withDeclaringType(TYPE_PATH)),
+                            p,
+                            getCursor().getParentOrThrow()
+                    );
+                }
+            }
+            return super.visitMethodInvocation(method, p);
+        }
+
+        private Expression unwrap(Expression expression) {
+            if (expression instanceof J.Parentheses) {
+                //noinspection unchecked
+                return unwrap(((J.Parentheses<Expression>) expression).getTree());
+            } else {
+                return expression;
+            }
+        }
+
+        private J.MethodInvocation replaceGetCanonicalPath(J.MethodInvocation getCanonicalPath) {
+            final JavaType.Method type =
+                    getCanonicalPath
+                            .getMethodType()
+                            .withName("getCanonicalFile");
+            final J.MethodInvocation getCanonicalFileSubject =
+                    getCanonicalPath
+                            .withName(getCanonicalPath.getName().withSimpleName("getCanonicalFile"))
+                            .withMethodType(type);
+
+            final JavaType.Method toPathMethod = new JavaType.Method(
+                    null,
+                    Flag.Public.getBitMask(),
+                    TYPE_FILE,
+                    "toPath",
+                    TYPE_PATH,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    null,
+                    null
+            );
+            return new J.MethodInvocation(
+                    Tree.randomId(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    JRightPadded.build(getCanonicalFileSubject),
+                    null,
+                    new J.Identifier(
+                            Tree.randomId(),
+                            Space.EMPTY,
+                            Markers.EMPTY,
+                            "toPath",
+                            null,
+                            null
+                    ),
+                    JContainer.empty(),
+                    toPathMethod
+            );
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -57,10 +57,14 @@ public class PartialPathTraversalVulnerability extends Recipe {
     }
 
     private static class PartialPathTraversalVulnerabilityVisitor<P> extends JavaIsoVisitor<P> {
-        private static final JavaType.FullyQualified TYPE_FILE =
-                TypeUtils.asFullyQualified(JavaType.buildType("java.io.File"));
-        private static final JavaType.FullyQualified TYPE_PATH =
-                TypeUtils.asFullyQualified(JavaType.buildType("java.io.Path"));
+        private final JavaTemplate toPathTemplate =
+                JavaTemplate
+                        .builder(this::getCursor, "#{any(java.io.File)}.getCanonicalFile().toPath()")
+                        .build();
+        private final JavaTemplate pathStartsWithTemplate =
+                JavaTemplate
+                        .builder(this::getCursor, "#{any(java.nio.file.Path)}.startsWith(#{any(java.nio.file.Path)})")
+                        .build();
 
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
@@ -76,14 +80,13 @@ public class PartialPathTraversalVulnerability extends Recipe {
                             replaceGetCanonicalPath(getCanonicalPathSubject);
                     final J.MethodInvocation getCanonicalPathArgumentReplacement =
                             replaceGetCanonicalPath(getCanonicalPathArgument);
-                    return maybeAutoFormat(
-                            method,
-                            method.withSelect(getCanonicalPathSubjectReplacement)
-                                    .withArguments(Collections.singletonList(getCanonicalPathArgumentReplacement))
-                                    .withMethodType(method.getMethodType().withDeclaringType(TYPE_PATH)),
-                            p,
-                            getCursor().getParentOrThrow()
-                    );
+                    return method
+                            .withTemplate(
+                                    pathStartsWithTemplate,
+                                    method.getCoordinates().replace(),
+                                    getCanonicalPathSubjectReplacement,
+                                    getCanonicalPathArgumentReplacement
+                            );
                 }
             }
             return super.visitMethodInvocation(method, p);
@@ -101,10 +104,7 @@ public class PartialPathTraversalVulnerability extends Recipe {
         private J.MethodInvocation replaceGetCanonicalPath(J.MethodInvocation getCanonicalPath) {
             return getCanonicalPath
                     .withTemplate(
-                            JavaTemplate.builder(
-                                    this::getCursor,
-                                    "#{any(java.io.File)}.getCanonicalFile().toPath()"
-                            ).build(),
+                            toPathTemplate,
                             getCanonicalPath.getCoordinates().replace(),
                             getCanonicalPath.getSelect()
                     );

--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -2,15 +2,14 @@ package org.openrewrite.java.security;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
-import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.*;
-import org.openrewrite.marker.Markers;
 
 import java.util.Collections;
 import java.util.Set;
@@ -99,44 +98,16 @@ public class PartialPathTraversalVulnerability extends Recipe {
             }
         }
 
-        private static J.MethodInvocation replaceGetCanonicalPath(J.MethodInvocation getCanonicalPath) {
-            final JavaType.Method type =
-                    getCanonicalPath
-                            .getMethodType()
-                            .withName("getCanonicalFile");
-            final J.MethodInvocation getCanonicalFileSubject =
-                    getCanonicalPath
-                            .withName(getCanonicalPath.getName().withSimpleName("getCanonicalFile"))
-                            .withMethodType(type);
-
-            final JavaType.Method toPathMethod = new JavaType.Method(
-                    null,
-                    Flag.Public.getBitMask(),
-                    TYPE_FILE,
-                    "toPath",
-                    TYPE_PATH,
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    null,
-                    null
-            );
-            return new J.MethodInvocation(
-                    Tree.randomId(),
-                    Space.EMPTY,
-                    Markers.EMPTY,
-                    JRightPadded.build(getCanonicalFileSubject),
-                    null,
-                    new J.Identifier(
-                            Tree.randomId(),
-                            Space.EMPTY,
-                            Markers.EMPTY,
-                            "toPath",
-                            null,
-                            null
-                    ),
-                    JContainer.empty(),
-                    toPathMethod
-            );
+        private J.MethodInvocation replaceGetCanonicalPath(J.MethodInvocation getCanonicalPath) {
+            return getCanonicalPath
+                    .withTemplate(
+                            JavaTemplate.builder(
+                                    this::getCursor,
+                                    "#{any(java.io.File)}.getCanonicalFile().toPath()"
+                            ).build(),
+                            getCanonicalPath.getCoordinates().replace(),
+                            getCanonicalPath.getSelect()
+                    );
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -26,6 +26,15 @@ public class PartialPathTraversalVulnerability extends Recipe {
     }
 
     @Override
+    public String getDescription() {
+        return "Replaces `dir.getCanonicalPath().startsWith(parent.getCanonicalPath()`, which is vulnerable to partial path traversal attacks, with the more secure `dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())`.\n\n" +
+                "To demonstrate this vulnerability, consider `\"/usr/outnot\".startsWith(\"/usr/out\")`. The check is bypassed although `/outnot` is not under the `/out` directory. " +
+                "It's important to understand that the terminating slash may be removed when using various `String` representations of the `File` object. " +
+                "For example, on Linux, `println(new File(\"/var\"))` will print `/var`, but `println(new File(\"/var\", \"/\")` will print `/var/`; " +
+                "however, `println(new File(\"/var\", \"/\").getCanonicalPath())` will print `/var`.";
+    }
+
+    @Override
     protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
         return new JavaVisitor<ExecutionContext>() {
             @Override
@@ -75,7 +84,7 @@ public class PartialPathTraversalVulnerability extends Recipe {
             return super.visitMethodInvocation(method, p);
         }
 
-        private Expression unwrap(Expression expression) {
+        private static Expression unwrap(Expression expression) {
             if (expression instanceof J.Parentheses) {
                 //noinspection unchecked
                 return unwrap(((J.Parentheses<Expression>) expression).getTree());
@@ -84,7 +93,7 @@ public class PartialPathTraversalVulnerability extends Recipe {
             }
         }
 
-        private J.MethodInvocation replaceGetCanonicalPath(J.MethodInvocation getCanonicalPath) {
+        private static J.MethodInvocation replaceGetCanonicalPath(J.MethodInvocation getCanonicalPath) {
             final JavaType.Method type =
                     getCanonicalPath
                             .getMethodType()

--- a/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
@@ -1,0 +1,79 @@
+package org.openrewrite.java.security
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+class PartialPathTraversalVulnerabilityTest: JavaRecipeTest {
+    override val recipe: Recipe
+        get() = PartialPathTraversalVulnerability()
+
+    /**
+     * [ESAPI Vulnerability Fix](https://github.com/ESAPI/esapi-java-legacy/commit/a0d67b75593878b1b6e39e2acc1773b3effedb2a)
+     */
+    @Test
+    fun `ESAPI CVE-2022-23457 example`() = assertChanged(
+        before = """
+        import java.io.File;
+        import java.io.UncheckedIOException;
+
+        class A {
+            void foo(File dir, File parent) {
+                if (!dir.getCanonicalPath().startsWith(parent.getCanonicalPath())) {
+                    throw new UncheckedIOException("Invalid directory: " + dir.getCanonicalPath());
+                }
+            }
+        }
+        """,
+        after = """
+        import java.io.File;
+        import java.io.UncheckedIOException;
+
+        class A {
+            void foo(File dir, File parent) {
+                if (!dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())) {
+                    throw new UncheckedIOException("Invalid directory: " + dir.getCanonicalPath());
+                }
+            }
+        }
+        """
+    )
+
+    @Test
+    fun `parentheses wrapped call chain`() = assertChanged(
+        before = """
+        import java.io.File;
+
+        class A {
+            void foo(File dir, File parent) {
+                (dir.getCanonicalPath()).startsWith((parent.getCanonicalPath()));
+            }
+        }
+        """,
+        after = """
+        import java.io.File;
+
+        class A {
+            void foo(File dir, File parent) {
+                dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath());
+            }
+        }
+        """
+    )
+
+    @Test
+    fun `startsWith on String call`() = assertUnchanged(
+        before = """
+        import java.io.File;
+
+        class A {
+            void foo(File dir, File parent) {
+                dir.getCanonicalPath();
+                if ("potato".startsWith(parent.getCanonicalPath())) {
+                    System.out.println("Hello!");
+                }
+            }
+        }
+        """
+    )
+}


### PR DESCRIPTION
Adds a remediation for partial path traversal vulnerabilities.

Example vulnerability
```java
if (!dir.getCanonicalPath().startsWith(parent.getCanonicalPath())) {
    throw new UncheckedIOException("Invalid directory: " + dir.getCanonicalPath());
}
```

Vulnerability: https://github.com/ESAPI/esapi-java-legacy/security/advisories/GHSA-8m5h-hrqm-pxm2
Credit to @JarLob for this vulnerability

Here's an example of the vulnerability: `"/usr/outnot".startsWith("/usr/out")`