### PR TITLE
Add `startsWith(any(String))` support to partial-path-traversal fix

### DIFF
--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -76,9 +76,14 @@ public class PartialPathTraversalVulnerability extends Recipe {
                 JavaTemplate
                         .builder(this::getCursor, "#{any(java.io.File)}.getCanonicalFile().toPath()")
                         .build();
-        private final JavaTemplate pathStartsWithTemplate =
+        private final JavaTemplate pathStartsWithPathTemplate =
                 JavaTemplate
                         .builder(this::getCursor, "#{any(java.nio.file.Path)}.startsWith(#{any(java.nio.file.Path)})")
+                        .build();
+
+        private final JavaTemplate pathStartsWithStringTemplate =
+                JavaTemplate
+                        .builder(this::getCursor, "#{any(java.nio.file.Path)}.startsWith(#{any(String)})")
                         .build();
 
         @Override
@@ -87,21 +92,31 @@ public class PartialPathTraversalVulnerability extends Recipe {
                 assert method.getSelect() != null : "Select is null for `startsWith`";
                 final Expression select = unwrap(method.getSelect());
                 final Expression argument = unwrap(method.getArguments().get(0));
-                if (getCanonicalPathMatcher.matches(select) &&
-                        getCanonicalPathMatcher.matches(argument)) {
+                if (getCanonicalPathMatcher.matches(select)) {
                     final J.MethodInvocation getCanonicalPathSubject = (J.MethodInvocation) select;
-                    final J.MethodInvocation getCanonicalPathArgument = (J.MethodInvocation) argument;
                     final J.MethodInvocation getCanonicalPathSubjectReplacement =
                             replaceGetCanonicalPath(getCanonicalPathSubject);
-                    final J.MethodInvocation getCanonicalPathArgumentReplacement =
-                            replaceGetCanonicalPath(getCanonicalPathArgument);
-                    return method
-                            .withTemplate(
-                                    pathStartsWithTemplate,
-                                    method.getCoordinates().replace(),
-                                    getCanonicalPathSubjectReplacement,
-                                    getCanonicalPathArgumentReplacement
-                            );
+                    if (getCanonicalPathMatcher.matches(argument)) {
+                        final J.MethodInvocation getCanonicalPathArgument = (J.MethodInvocation) argument;
+                        final J.MethodInvocation getCanonicalPathArgumentReplacement =
+                                replaceGetCanonicalPath(getCanonicalPathArgument);
+                        return method
+                                .withTemplate(
+                                        pathStartsWithPathTemplate,
+                                        method.getCoordinates().replace(),
+                                        getCanonicalPathSubjectReplacement,
+                                        getCanonicalPathArgumentReplacement
+                                );
+                    } else {
+                        return method
+                                .withTemplate(
+                                        pathStartsWithStringTemplate,
+                                        method.getCoordinates().replace(),
+                                        getCanonicalPathSubjectReplacement,
+                                        argument
+                                );
+                    }
+
                 }
             }
             return super.visitMethodInvocation(method, p);

--- a/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
@@ -33,24 +33,24 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
         java(
             """
             import java.io.File;
-            import java.io.UncheckedIOException;
-    
+            import java.io.IOException;
+
             class A {
-                void foo(File dir, File parent) {
+                void foo(File dir, File parent) throws IOException {
                     if (!dir.getCanonicalPath().startsWith(parent.getCanonicalPath())) {
-                        throw new UncheckedIOException("Invalid directory: " + dir.getCanonicalPath());
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
                     }
                 }
             }
             """,
             """
             import java.io.File;
-            import java.io.UncheckedIOException;
-    
+            import java.io.IOException;
+
             class A {
-                void foo(File dir, File parent) {
+                void foo(File dir, File parent) throws IOException {
                     if (!dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())) {
-                        throw new UncheckedIOException("Invalid directory: " + dir.getCanonicalPath());
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
                     }
                 }
             }
@@ -63,7 +63,7 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
         java(
             """
             import java.io.File;
-    
+
             class A {
                 void foo(File dir, File parent) {
                     (dir.getCanonicalPath()).startsWith((parent.getCanonicalPath()));
@@ -72,7 +72,7 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
             """,
             """
             import java.io.File;
-    
+
             class A {
                 void foo(File dir, File parent) {
                     dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath());
@@ -87,12 +87,44 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
         java(
             """
             import java.io.File;
-    
+
             class A {
                 void foo(File dir, File parent) {
                     dir.getCanonicalPath();
                     if ("potato".startsWith(parent.getCanonicalPath())) {
                         System.out.println("Hello!");
+                    }
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun `getCanonicalPath startsWith string`() = rewriteRun(
+        java(
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentPath = parent.getCanonicalPath();
+                    if (!dir.getCanonicalPath().startsWith(parentPath)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """,
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentPath = parent.getCanonicalPath();
+                    if (!dir.getCanonicalFile().toPath().startsWith(parentPath)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
                     }
                 }
             }


### PR DESCRIPTION
When I wrote the original, I didn't realize a `Path#startsWith(String)` override existed
