### PR TITLE
Complete support for Data Flow support for the Partial Path Traversal fix

### DIFF
--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -88,15 +88,19 @@ public class PartialPathTraversalVulnerability extends Recipe {
                         .builder(this::getCursor, "#{any(java.nio.file.Path)}.startsWith(#{any(String)})")
                         .build();
 
-        private static final class GetCanonicalPathToStartsWithLocalFlow extends LocalFlowSpec<J.MethodInvocation, J.MethodInvocation> {
+        private static final class GetCanonicalPathToStartsWithLocalFlow extends LocalFlowSpec<J.MethodInvocation, J.Identifier> {
             @Override
             public boolean isSource(J.MethodInvocation source, Cursor cursor) {
                 return getCanonicalPathMatcher.matches(source);
             }
 
             @Override
-            public boolean isSink(J.MethodInvocation sink, Cursor cursor) {
-                return startsWithMatcher.matches(sink) && sink.getSelect() instanceof J.Identifier;
+            public boolean isSink(J.Identifier sink, Cursor cursor) {
+                J.MethodInvocation maybeStartsWith = cursor.firstEnclosing(J.MethodInvocation.class);
+                if (maybeStartsWith != null) {
+                    return startsWithMatcher.matches(maybeStartsWith) && maybeStartsWith.getSelect() == sink;
+                }
+                return false;
             }
         }
 
@@ -104,24 +108,50 @@ public class PartialPathTraversalVulnerability extends Recipe {
 
             @Override
             public boolean isSource(Expression source, Cursor cursor) {
-                return !isSafePartialPathExpression(source) && !(source instanceof J.Identifier);
+                return isSourceFilter(source, cursor);
             }
 
             @Override
             public boolean isSink(Expression sink, Cursor cursor) {
+                // Any method argument for the method `startsWith`
                 J.MethodInvocation maybeStartsWith = cursor.firstEnclosing(J.MethodInvocation.class);
                 if (maybeStartsWith != null) {
                     return startsWithMatcher.matches(maybeStartsWith) && maybeStartsWith.getArguments().contains(sink);
                 }
                 return false;
             }
+
+            static boolean isSourceFilter(Expression source, Cursor cursor) {
+                if (cursor.firstEnclosing(J.Import.class) != null) {
+                    return false;
+                } else if (source instanceof J.Literal) {
+                    // Ignore the literal 'null' as a source as the value will probably be reassigned
+                    return ((J.Literal) source).getValue() != null;
+                }
+                // A source is any add expression that does not have a `/` appended at the end of it
+                return !isSafePartialPathExpression(source) && !(
+                        source instanceof J.Identifier ||
+                                source instanceof J.Assignment ||
+                                source instanceof J.AssignmentOperation ||
+                                source instanceof J.Primitive ||
+                                source instanceof J.Empty
+                );
+            }
         }
 
         @Override
         public Expression visitExpression(Expression expression, P p) {
-            SinkFlow<Expression, Expression> sinks = dataflow().findSinks(new NotSafePartialPathTraversalLocalFlow());
-            if (!sinks.isEmpty()) {
-                getCursor().dropParentUntil(SourceFile.class::isInstance).putMessage("unsafeArgument", sinks.getSinks());
+            if (NotSafePartialPathTraversalLocalFlow.isSourceFilter(expression, getCursor())) {
+                // CASE: Find any expression that is considered an 'unsafe' source
+                SinkFlow<Expression, Expression> sinks = dataflow().findSinks(new NotSafePartialPathTraversalLocalFlow());
+                if (!sinks.isEmpty()) {
+                    Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
+                    List<Expression> unsafeArgument =
+                            parentCursor.getMessage("unsafeArgument", new ArrayList<>(sinks.getSinks().size()));
+                    unsafeArgument.addAll(sinks.getSinks());
+                    parentCursor
+                            .putMessage("unsafeArgument", unsafeArgument);
+                }
             }
             return super.visitExpression(expression, p);
         }
@@ -131,16 +161,17 @@ public class PartialPathTraversalVulnerability extends Recipe {
             Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
             if (getCanonicalPathMatcher.matches(method)) {
                 // CASE: ...getCanonicalPath();
-                SinkFlow<J.MethodInvocation, J.MethodInvocation> sinkFlow = dataflow().findSinks(new GetCanonicalPathToStartsWithLocalFlow());
+                SinkFlow<J.MethodInvocation, J.Identifier> sinkFlow = dataflow().findSinks(new GetCanonicalPathToStartsWithLocalFlow());
                 Map<Expression, Expression> replacement = parentCursor.getMessage("replacement", new HashMap<>());
                 sinkFlow.getSinks().forEach(sink -> {
                     // MAP of:
                     // String k = VALUE /** VALUE **/.getCanonicalPath();
                     // k /** KEY **/.startsWith(...);
-                    replacement.put(sink.getSelect(), sinkFlow.getSource().getSelect());
+                    replacement.put(sink, sinkFlow.getSource().getSelect());
                 });
                 parentCursor.putMessage("replacement", replacement);
             } else if (startsWithMatcher.matches(method)) {
+                // CASE: ...startsWith(...);
                 assert method.getSelect() != null : "Select is null for `startsWith`";
                 final Expression select = unwrap(method.getSelect());
                 final Expression argument = unwrap(method.getArguments().get(0));
@@ -149,7 +180,10 @@ public class PartialPathTraversalVulnerability extends Recipe {
                     unsafeArguments = Collections.emptyList();
                 }
 
-                if (!isSafePartialPathExpression(argument)) {
+                if (unsafeArguments.contains(argument) ||
+                        !(isSafePartialPathExpression(argument) || argument instanceof J.Identifier)) {
+                    // CASE: startsWith is passed an argument or variable represented by an argument
+                    // that is not terminated by a `/`
                     if (getCanonicalPathMatcher.matches(select)) {
                         // CASE: getCanonicalPath().startsWith(...)
                         final J.MethodInvocation getCanonicalPathSelect = (J.MethodInvocation) select;
@@ -190,8 +224,16 @@ public class PartialPathTraversalVulnerability extends Recipe {
                     // CASE: ...startsWith(... + ...);
                     Expression right = unwrap(concatArgument.getRight());
                     if (right instanceof J.FieldAccess) {
-                        // CASE: ...startsWith(... + field);
-                        return true;
+                        // CASE:
+                        // - ...startsWith(... + File.separator);
+                        // - ...startsWith(... + File.seperatorChar);
+                        J.FieldAccess fieldAccess = (J.FieldAccess) right;
+                        String fieldName = fieldAccess.getName().getSimpleName();
+                        // TODO: Include filtering for declaring type being `java.io.File`.
+                        // This is currently not possible because `J.FieldAccess` does not have `JavaType.Variable`
+                        // information attached to it currently.
+                        // See https://github.com/openrewrite/rewrite/issues/1813
+                        return fieldName.equals("separatorChar") || fieldName.equals("separator");
                     } else if (right instanceof J.Literal) {
                         // CASE:
                         // - ...startsWith(... + "/);

--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -151,7 +151,7 @@ public class PartialPathTraversalVulnerability extends Recipe {
                     Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
                     // If an unsafeArgument list already exists, get it
                     List<Expression> unsafeArgument =
-                            parentCursor.getMessage("unsafeArgument", new ArrayList<>(sinks.getSinks().size()));
+                            parentCursor.computeMessageIfAbsent("unsafeArgument", v -> new ArrayList<>(sinks.getSinks().size()));
                     // Add this set of sinks to it
                     unsafeArgument.addAll(sinks.getSinks());
                     // Put it back
@@ -183,7 +183,7 @@ public class PartialPathTraversalVulnerability extends Recipe {
             SinkFlow<J.MethodInvocation, J.Identifier> sinkFlow =
                     dataflow().findSinks(new GetCanonicalPathToStartsWithLocalFlow());
             Map<Expression, Expression> replacement =
-                    parentCursor.getMessage("replacement", new HashMap<>());
+                    parentCursor.computeMessageIfAbsent("replacement", v -> new HashMap<>());
             sinkFlow.getSinks().forEach(sink -> {
                 // MAP of:
                 // String k = VALUE /** VALUE **/.getCanonicalPath();
@@ -256,6 +256,10 @@ public class PartialPathTraversalVulnerability extends Recipe {
                         // information attached to it currently.
                         // See https://github.com/openrewrite/rewrite/issues/1813
                         return fieldName.equals("separatorChar") || fieldName.equals("separator");
+                    } else if (right instanceof J.Identifier) {
+                        J.Identifier ident = (J.Identifier)right;
+                        return ident.getFieldType() != null && "separatorChar".equals(ident.getSimpleName())
+                                && TypeUtils.isOfClassType(ident.getFieldType().getOwner(), "java.io.File");
                     } else if (right instanceof J.Literal) {
                         // CASE:
                         // - ...startsWith(... + "/);

--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -25,9 +25,7 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.dataflow.LocalFlowSpec;
 import org.openrewrite.java.dataflow.analysis.SinkFlow;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.*;
 
 import java.util.*;
 
@@ -129,7 +127,7 @@ public class PartialPathTraversalVulnerability extends Recipe {
                     return false;
                 } else if (source instanceof J.Literal) {
                     // Ignore the literal 'null' as a source as the value will probably be reassigned
-                    return ((J.Literal) source).getValue() != null;
+                    return source.getType() != JavaType.Primitive.Null;
                 }
                 // A source is any add expression that does not have a `/` appended at the end of it
                 return !isSafePartialPathExpression(source) && !(
@@ -245,21 +243,33 @@ public class PartialPathTraversalVulnerability extends Recipe {
                 if (J.Binary.Type.Addition.equals(concatArgument.getOperator())) {
                     // CASE: ...startsWith(... + ...);
                     Expression right = unwrap(concatArgument.getRight());
-                    if (right instanceof J.FieldAccess) {
+                    if (right instanceof J.FieldAccess || right instanceof J.Identifier) {
                         // CASE:
                         // - ...startsWith(... + File.separator);
                         // - ...startsWith(... + File.seperatorChar);
-                        J.FieldAccess fieldAccess = (J.FieldAccess) right;
-                        String fieldName = fieldAccess.getName().getSimpleName();
-                        // TODO: Include filtering for declaring type being `java.io.File`.
-                        // This is currently not possible because `J.FieldAccess` does not have `JavaType.Variable`
-                        // information attached to it currently.
-                        // See https://github.com/openrewrite/rewrite/issues/1813
-                        return fieldName.equals("separatorChar") || fieldName.equals("separator");
-                    } else if (right instanceof J.Identifier) {
-                        J.Identifier ident = (J.Identifier)right;
-                        return ident.getFieldType() != null && "separatorChar".equals(ident.getSimpleName())
-                                && TypeUtils.isOfClassType(ident.getFieldType().getOwner(), "java.io.File");
+                        // - ...startsWith(... + separator);
+                        // - ...startsWith(... + seperatorChar);
+                        J.Identifier nameIdentifier;
+                        JavaType type;
+                        if (right instanceof J.FieldAccess) {
+                            // CASE:
+                            // - ...startsWith(... + File.separator);
+                            // - ...startsWith(... + File.seperatorChar);
+                            nameIdentifier = ((J.FieldAccess) right).getName();
+                            type = ((J.FieldAccess) right).getTarget().getType();
+                        } else {
+                            // CASE:
+                            // - ...startsWith(... + separator); statically imported from java.io.File
+                            // - ...startsWith(... + seperatorChar); statically imported from java.io.File
+                            if (((J.Identifier) right).getFieldType() == null) {
+                                return false;
+                            }
+                            nameIdentifier = (J.Identifier) right;
+                            type = ((J.Identifier) right).getFieldType().getOwner();
+                        }
+                        final String name = nameIdentifier.getSimpleName();
+                        return TypeUtils.isOfClassType(type, "java.io.File")
+                                && (name.equals("separator") || name.equals("separatorChar"));
                     } else if (right instanceof J.Literal) {
                         // CASE:
                         // - ...startsWith(... + "/);

--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -91,11 +91,13 @@ public class PartialPathTraversalVulnerability extends Recipe {
         private static final class GetCanonicalPathToStartsWithLocalFlow extends LocalFlowSpec<J.MethodInvocation, J.Identifier> {
             @Override
             public boolean isSource(J.MethodInvocation source, Cursor cursor) {
+                // SOURCE: Any call to `File#getCanonicalPath()`
                 return getCanonicalPathMatcher.matches(source);
             }
 
             @Override
             public boolean isSink(J.Identifier sink, Cursor cursor) {
+                // SINK: Any J.Identifier that is the select (CodeQL: 'qualifier') of a call to `String#startsWith(String)`
                 J.MethodInvocation maybeStartsWith = cursor.firstEnclosing(J.MethodInvocation.class);
                 if (maybeStartsWith != null) {
                     return startsWithMatcher.matches(maybeStartsWith) && maybeStartsWith.getSelect() == sink;
@@ -108,12 +110,13 @@ public class PartialPathTraversalVulnerability extends Recipe {
 
             @Override
             public boolean isSource(Expression source, Cursor cursor) {
+                // SOURCE: Any expression that isn't terminated by the `/` character
                 return isSourceFilter(source, cursor);
             }
 
             @Override
             public boolean isSink(Expression sink, Cursor cursor) {
-                // Any method argument for the method `startsWith`
+                // SINK: method argument for the method `String#startsWith`
                 J.MethodInvocation maybeStartsWith = cursor.firstEnclosing(J.MethodInvocation.class);
                 if (maybeStartsWith != null) {
                     return startsWithMatcher.matches(maybeStartsWith) && maybeStartsWith.getArguments().contains(sink);
@@ -146,9 +149,12 @@ public class PartialPathTraversalVulnerability extends Recipe {
                 SinkFlow<Expression, Expression> sinks = dataflow().findSinks(new NotSafePartialPathTraversalLocalFlow());
                 if (!sinks.isEmpty()) {
                     Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
+                    // If an unsafeArgument list already exists, get it
                     List<Expression> unsafeArgument =
                             parentCursor.getMessage("unsafeArgument", new ArrayList<>(sinks.getSinks().size()));
+                    // Add this set of sinks to it
                     unsafeArgument.addAll(sinks.getSinks());
+                    // Put it back
                     parentCursor
                             .putMessage("unsafeArgument", unsafeArgument);
                 }
@@ -161,60 +167,76 @@ public class PartialPathTraversalVulnerability extends Recipe {
             Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
             if (getCanonicalPathMatcher.matches(method)) {
                 // CASE: ...getCanonicalPath();
-                SinkFlow<J.MethodInvocation, J.Identifier> sinkFlow = dataflow().findSinks(new GetCanonicalPathToStartsWithLocalFlow());
-                Map<Expression, Expression> replacement = parentCursor.getMessage("replacement", new HashMap<>());
-                sinkFlow.getSinks().forEach(sink -> {
-                    // MAP of:
-                    // String k = VALUE /** VALUE **/.getCanonicalPath();
-                    // k /** KEY **/.startsWith(...);
-                    replacement.put(sink, sinkFlow.getSource().getSelect());
-                });
-                parentCursor.putMessage("replacement", replacement);
+                visitGetCanonicalPathMethodInvocation(parentCursor);
             } else if (startsWithMatcher.matches(method)) {
                 // CASE: ...startsWith(...);
-                assert method.getSelect() != null : "Select is null for `startsWith`";
-                final Expression select = unwrap(method.getSelect());
-                final Expression argument = unwrap(method.getArguments().get(0));
-                List<Expression> unsafeArguments = parentCursor.getMessage("unsafeArgument");
-                if (unsafeArguments == null) {
-                    unsafeArguments = Collections.emptyList();
+                J.MethodInvocation newStartsWithMethod =
+                        visitStartsWithMethodInvocation(method, parentCursor);
+                if (newStartsWithMethod != null) {
+                    return newStartsWithMethod;
                 }
+            }
+            return super.visitMethodInvocation(method, p);
+        }
 
-                if (unsafeArguments.contains(argument) ||
-                        !(isSafePartialPathExpression(argument) || argument instanceof J.Identifier)) {
-                    // CASE: startsWith is passed an argument or variable represented by an argument
-                    // that is not terminated by a `/`
-                    if (getCanonicalPathMatcher.matches(select)) {
-                        // CASE: getCanonicalPath().startsWith(...)
-                        final J.MethodInvocation getCanonicalPathSelect = (J.MethodInvocation) select;
-                        final J.MethodInvocation getCanonicalPathSelectReplacement =
-                                replaceGetCanonicalPath(getCanonicalPathSelect);
+        private void visitGetCanonicalPathMethodInvocation(Cursor parentCursor) {
+            SinkFlow<J.MethodInvocation, J.Identifier> sinkFlow =
+                    dataflow().findSinks(new GetCanonicalPathToStartsWithLocalFlow());
+            Map<Expression, Expression> replacement =
+                    parentCursor.getMessage("replacement", new HashMap<>());
+            sinkFlow.getSinks().forEach(sink -> {
+                // MAP of:
+                // String k = VALUE /** VALUE **/.getCanonicalPath();
+                // k /** KEY **/.startsWith(...);
+                replacement.put(sink, sinkFlow.getSource().getSelect());
+            });
+            parentCursor.putMessage("replacement", replacement);
+        }
+
+        @Nullable
+        private J.MethodInvocation visitStartsWithMethodInvocation(J.MethodInvocation method, Cursor parentCursor) {
+            assert method.getSelect() != null : "Select is null for `startsWith`";
+            final Expression select = unwrap(method.getSelect());
+            final Expression argument = unwrap(method.getArguments().get(0));
+            List<Expression> unsafeArguments = parentCursor.getMessage("unsafeArgument");
+            if (unsafeArguments == null) {
+                unsafeArguments = Collections.emptyList();
+            }
+
+            if (unsafeArguments.contains(argument) ||
+                    !(isSafePartialPathExpression(argument) || argument instanceof J.Identifier)) {
+                // CASE: startsWith is passed an argument or variable represented by an argument
+                // that is not terminated by a `/`
+                if (getCanonicalPathMatcher.matches(select)) {
+                    // CASE: getCanonicalPath().startsWith(...)
+                    final J.MethodInvocation getCanonicalPathSelect = (J.MethodInvocation) select;
+                    final J.MethodInvocation getCanonicalPathSelectReplacement =
+                            replaceGetCanonicalPath(getCanonicalPathSelect);
+                    return replaceWithPathStartsWithMethodInvocation(
+                            method,
+                            argument,
+                            getCanonicalPathSelectReplacement
+                    );
+                } else if (parentCursor.getMessage("replacement") != null) {
+                    // CASE: canonicalPath.startsWith(...)
+                    final Expression alternateSelect =
+                            ((Map<Expression, Expression>) parentCursor.getMessage("replacement"))
+                                    .get(select);
+                    if (alternateSelect != null) {
+                        J.MethodInvocation getCanonicalPathSelectReplacement = select.withTemplate(
+                                toPathGetCanonicalFileTemplate,
+                                ((J.Identifier) select).getCoordinates().replace(),
+                                alternateSelect
+                        );
                         return replaceWithPathStartsWithMethodInvocation(
                                 method,
                                 argument,
                                 getCanonicalPathSelectReplacement
                         );
-                    } else if (parentCursor.getMessage("replacement") != null) {
-                        // CASE: canonicalPath.startsWith(...)
-                        final Expression alternateSelect =
-                                ((Map<Expression, Expression>) parentCursor.getMessage("replacement"))
-                                        .get(select);
-                        if (alternateSelect != null) {
-                            J.MethodInvocation getCanonicalPathSelectReplacement = select.withTemplate(
-                                    toPathGetCanonicalFileTemplate,
-                                    ((J.Identifier) select).getCoordinates().replace(),
-                                    alternateSelect
-                            );
-                            return replaceWithPathStartsWithMethodInvocation(
-                                    method,
-                                    argument,
-                                    getCanonicalPathSelectReplacement
-                            );
-                        }
                     }
                 }
             }
-            return super.visitMethodInvocation(method, p);
+            return null;
         }
 
         private static boolean isSafePartialPathExpression(Expression expression) {

--- a/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
@@ -447,6 +447,26 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
     )
 
     @Test
+    fun `getCanonicalPath startsWith string ending with static import of File seperatorChar assigned to variable`() = rewriteRun(
+        java(
+            """
+            import java.io.File;
+            import java.io.IOException;
+            import static java.io.File.separatorChar;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath() + separatorChar;
+                    if (!dir.getCanonicalPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """
+        )
+    )
+
+    @Test
     fun `getCanonicalPath startsWith string ending with File seperatorChar assigned to variable twice`() = rewriteRun(
         java(
             """

--- a/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test
 import org.openrewrite.test.RecipeSpec
 import org.openrewrite.test.RewriteTest
 
+@Suppress("RedundantSuppression")
 class PartialPathTraversalVulnerabilityTest : RewriteTest {
 
     override fun defaults(spec: RecipeSpec) {
@@ -64,7 +65,9 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
             """
             import java.io.File;
 
+            @SuppressWarnings("RedundantSuppression")
             class A {
+                @SuppressWarnings("ResultOfMethodCallIgnored")
                 void foo(File dir, File parent) {
                     (dir.getCanonicalPath()).startsWith((parent.getCanonicalPath()));
                 }
@@ -73,7 +76,9 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
             """
             import java.io.File;
 
+            @SuppressWarnings("RedundantSuppression")
             class A {
+                @SuppressWarnings("ResultOfMethodCallIgnored")
                 void foo(File dir, File parent) {
                     dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath());
                 }
@@ -351,7 +356,79 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
     )
 
     @Test
-    fun `getCanonicalPath startsWith string ending with File seperatorChar in variable`() = rewriteRun(
+    fun `getCanonicalPath startsWith string assigned to variable`() = rewriteRun(
+        java(
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath();
+                    if (!dir.getCanonicalPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """,
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath();
+                    if (!dir.getCanonicalFile().toPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun `getCanonicalPath startsWith string assigned to variable twice`() = rewriteRun(
+        java(
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath();
+                    String parentCanonical2 = parent.getCanonicalPath();
+                    if (!dir.getCanonicalPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                    if (!dir.getCanonicalPath().startsWith(parentCanonical2)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """,
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath();
+                    String parentCanonical2 = parent.getCanonicalPath();
+                    if (!dir.getCanonicalFile().toPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                    if (!dir.getCanonicalFile().toPath().startsWith(parentCanonical2)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun `getCanonicalPath startsWith string ending with File seperatorChar assigned to variable`() = rewriteRun(
         java(
             """
             import java.io.File;
@@ -370,13 +447,62 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
     )
 
     @Test
-    fun `getCanonicalPath startsWith string ending with File seperatorChar in variable in if`() = rewriteRun(
+    fun `getCanonicalPath startsWith string ending with File seperatorChar assigned to variable twice`() = rewriteRun(
         java(
             """
             import java.io.File;
             import java.io.IOException;
 
             class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath() + File.separatorChar;
+                    String parentCanonical2 = parent.getCanonicalPath() + File.separatorChar;
+                    if (!dir.getCanonicalPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                    if (!dir.getCanonicalPath().startsWith(parentCanonical2)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun `getCanonicalPath startsWith string ending with File separator assigned to variable`() = rewriteRun(
+        java(
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath() + File.separator;
+                    if (!dir.getCanonicalPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun `getCanonicalPath startsWith string ending with File seperatorChar assigned to variable in if`() = rewriteRun(
+        java(
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            @SuppressWarnings("RedundantSuppression")
+            class A {
+                @SuppressWarnings({
+                    "IfStatementWithIdenticalBranches",
+                    "MismatchedStringCase",
+                    "UnusedAssignment",
+                    "ResultOfMethodCallIgnored"
+                })
                 void foo(File dir, File parent, boolean branch) throws IOException {
                     String parentCanonical = null;
                     "test ".startsWith("somethingElse");
@@ -423,6 +549,38 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
                     if (branch) {
                         parentCanonical = parent.getCanonicalPath() + File.separatorChar;
                     }
+                    if (!dir.getCanonicalFile().toPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun `getCanonicalPath startsWith string ending with another string assigned to variable`() = rewriteRun(
+        java(
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath() + "/potato";
+                    if (!dir.getCanonicalPath().startsWith(parentCanonical)) {
+                        throw new IOException("Invalid directory: " + dir.getCanonicalPath());
+                    }
+                }
+            }
+            """,
+            """
+            import java.io.File;
+            import java.io.IOException;
+
+            class A {
+                void foo(File dir, File parent) throws IOException {
+                    String parentCanonical = parent.getCanonicalPath() + "/potato";
                     if (!dir.getCanonicalFile().toPath().startsWith(parentCanonical)) {
                         throw new IOException("Invalid directory: " + dir.getCanonicalPath());
                     }


### PR DESCRIPTION
Before:
```java
String canonicalPath = dir.getCanonicalPath();
if (!canonicalPath.startsWith(parent.getCanonicalPath())) {
    throw new IOException("Invalid directory: " + dir.getCanonicalPath());
}
```
After:
```java
String canonicalPath = dir.getCanonicalPath();
if (!dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())) {
    throw new IOException("Invalid directory: " + dir.getCanonicalPath());
}
```

However, due to an additional data flow configuration being used, the recipe is intelligent enough to know that the following two examples are _safe_ and should not be fixed:
```java
String parentCanonical = parent.getCanonicalPath() + '/';
if (!dir.getCanonicalPath().startsWith(parentCanonical)) {
    throw new IOException("Invalid directory: " + dir.getCanonicalPath());
}
```

```java
String parentCanonical = parent.getCanonicalPath() + File.separator;
if (!dir.getCanonicalPath().startsWith(parentCanonical)) {
    throw new IOException("Invalid directory: " + dir.getCanonicalPath());
}
```