### PR TITLE
Significantly improve performance of Partial Path Traversal

### DIFF
--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.security;
 
+import lombok.AllArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
@@ -94,7 +95,9 @@ public class PartialPathTraversalVulnerability extends Recipe {
                 .imports("java.nio.file.Paths")
                 .build();
 
+        @AllArgsConstructor
         private static final class GetCanonicalPathToStartsWithLocalFlow extends LocalFlowSpec<J.MethodInvocation, Expression> {
+            Expression currentStartsWithSelect;
             @Override
             public boolean isSource(J.MethodInvocation source, Cursor cursor) {
                 // SOURCE: Any call to `File#getCanonicalPath()`
@@ -104,8 +107,102 @@ public class PartialPathTraversalVulnerability extends Recipe {
             @Override
             public boolean isSink(Expression sink, Cursor cursor) {
                 // SINK: Any J.Identifier that is the select (CodeQL: 'qualifier') of a call to `String#startsWith(String)`
-                return startsWithInvocationMatcher.advanced().isSelect(cursor);
+                return currentStartsWithSelect == sink;
             }
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
+            Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
+            if (startsWithMatcher.matches(method)) {
+                // CASE: ...startsWith(...);
+                J.MethodInvocation newStartsWithMethod =
+                        visitStartsWithMethodInvocation(method, parentCursor);
+                if (newStartsWithMethod != null) {
+                    return newStartsWithMethod;
+                }
+            }
+            return super.visitMethodInvocation(method, p);
+        }
+
+        @Nullable
+        private J.MethodInvocation visitStartsWithMethodInvocation(J.MethodInvocation method, Cursor parentCursor) {
+            assert method.getSelect() != null : "Select is null for `startsWith`";
+            final Expression select = unwrap(method.getSelect());
+            final Expression argument = unwrap(method.getArguments().get(0));
+
+            if ((isSafePartialPathExpression(argument) || argument instanceof J.Identifier)) {
+                // `computeUnsafeArguments()` is potentially expensive, only compute it if needed
+                if (!computeUnsafeArguments().contains(argument)) {
+                    return null;
+                }
+            }
+
+            // CASE: startsWith is passed an argument or variable represented by an argument
+            // that is not terminated by a `/`
+            if (getCanonicalPathMatcher.matches(select)) {
+                // CASE: getCanonicalPath().startsWith(...)
+                final J.MethodInvocation getCanonicalPathSelect = (J.MethodInvocation) select;
+                final J.MethodInvocation getCanonicalPathSelectReplacement =
+                        replaceGetCanonicalPath(getCanonicalPathSelect);
+                return replaceWithPathStartsWithMethodInvocation(
+                        method,
+                        argument,
+                        getCanonicalPathSelectReplacement
+                );
+            } else {
+                // Compute a set of potential alternative select statements
+                final Set<Expression> alternateSelects = computeAlternateSelects(select);
+                if (alternateSelects.size() == 1) {
+                    Expression alternateSelect = alternateSelects.iterator().next();
+                    J.MethodInvocation getCanonicalPathSelectReplacement = method.getSelect().withTemplate(
+                            toPathGetCanonicalFileTemplate,
+                            ((J.Identifier) select).getCoordinates().replace(),
+                            alternateSelect
+                    );
+                    return replaceWithPathStartsWithMethodInvocation(
+                            method,
+                            argument,
+                            getCanonicalPathSelectReplacement
+                    );
+                } else if (!alternateSelects.isEmpty()) {
+                    // There are multiple possible alternative selects.
+                    // This is a super complicated case.
+                    // The best solution is to simply wrap the subject in `new File(...)` and use that.
+                    maybeAddImport("java.nio.file.Paths");
+                    J.MethodInvocation newSelect = method.getSelect().withTemplate(
+                            pathCreationNormalizeTemplate,
+                            ((J.Identifier) select).getCoordinates().replace(),
+                            method.getSelect()
+                    );
+                    return replaceWithPathStartsWithMethodInvocation(
+                            method,
+                            argument,
+                            newSelect
+                    );
+                }
+            }
+            return null;
+        }
+
+        private Set<Expression> computeAlternateSelects(Expression currentSelect) {
+            // Start visiting as high as possible.
+            Cursor outerExecutable = findOuterExecutableBlock();
+            final Set<Expression> alternateSelects = new HashSet<>();
+            new JavaIsoVisitor<Set<Expression>>() {
+                @Override
+                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Set<Expression> alternateSelectsInner) {
+                    if (getCanonicalPathMatcher.matches(method)) {
+                        dataflow().findSinks(new GetCanonicalPathToStartsWithLocalFlow(currentSelect)).ifPresent(sinkFlow -> {
+                            sinkFlow.getSinks().forEach(sink -> {
+                                alternateSelectsInner.add(sinkFlow.getSource().getSelect());
+                            });
+                        });
+                    }
+                    return super.visitMethodInvocation(method, alternateSelectsInner);
+                }
+            }.visit(outerExecutable.getValue(), alternateSelects, outerExecutable.getParentOrThrow());
+            return alternateSelects;
         }
 
         private static final class NotSafePartialPathTraversalLocalFlow extends LocalFlowSpec<Expression, Expression> {
@@ -140,129 +237,56 @@ public class PartialPathTraversalVulnerability extends Recipe {
             }
         }
 
-        @Override
-        public Expression visitExpression(Expression expression, P p) {
-            if (NotSafePartialPathTraversalLocalFlow.isSourceFilter(expression, getCursor())) {
-                // CASE: Find any expression that is considered an 'unsafe' source
-                dataflow().findSinks(new NotSafePartialPathTraversalLocalFlow()).ifPresent(sinks -> {
-                    if (!sinks.isEmpty()) {
-                        Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
-                        // If an unsafeArgument list already exists, get it
-                        List<Expression> unsafeArgument =
-                                parentCursor
-                                        .computeMessageIfAbsent(
-                                                "unsafeArgument",
-                                                v -> new ArrayList<>(sinks.getSinks().size())
-                                        );
-                        // Add this set of sinks to it
-                        unsafeArgument.addAll(sinks.getSinks());
-                        // Put it back
-                        parentCursor
-                                .putMessage("unsafeArgument", unsafeArgument);
+        /**
+         * Warning: This method is potentially expensive on first call.
+         */
+        private List<Expression> computeUnsafeArguments() {
+            // Start visiting as high as possible.
+            Cursor outerExecutable = findOuterExecutableBlock();
+            return outerExecutable.computeMessageIfAbsent("EXPENSIVE_COMPUTE_UNSAFE_ARGUMENTS", k -> {
+                final List<Expression> unsafeArguments = new ArrayList<>();
+                new JavaIsoVisitor<List<Expression>>() {
+                    @Override
+                    public Expression visitExpression(Expression expression, List<Expression> unsafeArgumentsInner) {
+                        if (NotSafePartialPathTraversalLocalFlow.isSourceFilter(expression, getCursor())) {
+                            // CASE: Find any expression that is considered an 'unsafe' source
+                            dataflow().findSinks(new NotSafePartialPathTraversalLocalFlow()).ifPresent(sinks -> {
+                                if (!sinks.isEmpty()) {
+                                    // Add this set of sinks to it
+                                    unsafeArgumentsInner.addAll(sinks.getSinks());
+                                }
+                            });
+                        }
+                        return super.visitExpression(expression, unsafeArgumentsInner);
                     }
-                });
-            }
-            return super.visitExpression(expression, p);
-        }
-
-        @Override
-        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
-            Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
-            if (getCanonicalPathMatcher.matches(method)) {
-                // CASE: ...getCanonicalPath();
-                visitGetCanonicalPathMethodInvocation(parentCursor);
-            } else if (startsWithMatcher.matches(method)) {
-                // CASE: ...startsWith(...);
-                J.MethodInvocation newStartsWithMethod =
-                        visitStartsWithMethodInvocation(method, parentCursor);
-                if (newStartsWithMethod != null) {
-                    return newStartsWithMethod;
-                }
-            }
-            return super.visitMethodInvocation(method, p);
-        }
-
-        private void visitGetCanonicalPathMethodInvocation(Cursor parentCursor) {
-            dataflow().findSinks(new GetCanonicalPathToStartsWithLocalFlow()).ifPresent(sinkFlow -> {
-                Map<Expression, Set<Expression>> replacement =
-                        parentCursor.computeMessageIfAbsent("replacement", k -> new HashMap<>());
-                sinkFlow.getSinks().forEach(sink -> {
-                    // MAP of:
-                    // String k = VALUE /** VALUE **/.getCanonicalPath();
-                    // k /** KEY **/.startsWith(...);
-                    Set<Expression> replacementSet = replacement.computeIfAbsent(sink, k -> new HashSet<>());
-                    replacementSet.add(sinkFlow.getSource().getSelect());
-                    replacement.put(sink, replacementSet);
-                });
-                parentCursor.putMessage("replacement", replacement);
+                }.visit(outerExecutable.getValue(), unsafeArguments, outerExecutable.getParentOrThrow());
+                return unsafeArguments;
             });
         }
 
-        @Nullable
-        private J.MethodInvocation visitStartsWithMethodInvocation(J.MethodInvocation method, Cursor parentCursor) {
-            assert method.getSelect() != null : "Select is null for `startsWith`";
-            final Expression select = unwrap(method.getSelect());
-            final Expression argument = unwrap(method.getArguments().get(0));
-            List<Expression> unsafeArguments = parentCursor.getMessage("unsafeArgument");
-            if (unsafeArguments == null) {
-                unsafeArguments = Collections.emptyList();
-            }
-
-            if (unsafeArguments.contains(argument) ||
-                    !(isSafePartialPathExpression(argument) || argument instanceof J.Identifier)) {
-                // CASE: startsWith is passed an argument or variable represented by an argument
-                // that is not terminated by a `/`
-                if (getCanonicalPathMatcher.matches(select)) {
-                    // CASE: getCanonicalPath().startsWith(...)
-                    final J.MethodInvocation getCanonicalPathSelect = (J.MethodInvocation) select;
-                    final J.MethodInvocation getCanonicalPathSelectReplacement =
-                            replaceGetCanonicalPath(getCanonicalPathSelect);
-                    return replaceWithPathStartsWithMethodInvocation(
-                            method,
-                            argument,
-                            getCanonicalPathSelectReplacement
-                    );
-                } else {
-                    @SuppressWarnings("unchecked")
-                    Map<Expression, Set<Expression>> replacementMap =
-                            parentCursor.getMessage("replacement");
-                    if (replacementMap != null) {
-                        // CASE: canonicalPath.startsWith(...)
-                        final Set<Expression> alternateSelects = replacementMap.get(select);
-                        if (alternateSelects != null) {
-                            if (alternateSelects.size() == 1) {
-                                Expression alternateSelect = alternateSelects.iterator().next();
-                                J.MethodInvocation getCanonicalPathSelectReplacement = method.getSelect().withTemplate(
-                                        toPathGetCanonicalFileTemplate,
-                                        ((J.Identifier) select).getCoordinates().replace(),
-                                        alternateSelect
-                                );
-                                return replaceWithPathStartsWithMethodInvocation(
-                                        method,
-                                        argument,
-                                        getCanonicalPathSelectReplacement
-                                );
-                            } else if (!alternateSelects.isEmpty()) {
-                                // There are multiple possible alternative selects.
-                                // This is a super complicated case.
-                                // The best solution is to simply wrap the subject in `new File(...)` and use that.
-                                maybeAddImport("java.nio.file.Paths");
-                                J.MethodInvocation newSelect = method.getSelect().withTemplate(
-                                        pathCreationNormalizeTemplate,
-                                        ((J.Identifier) select).getCoordinates().replace(),
-                                        method.getSelect()
-                                );
-                                return replaceWithPathStartsWithMethodInvocation(
-                                        method,
-                                        argument,
-                                        newSelect
-                                );
-                            }
-                        }
-                    }
+        /**
+         * Find the outermost executable {@link J.Block} that is an executable set of instructions.
+         * This is one of the following:
+         * <ul>
+         *     <li>A {@link J.Block} that is either static or an init block.</li>
+         *     <li>The block held by a {@link J.MethodInvocation}.</li>
+         * </ul>
+         */
+        private Cursor findOuterExecutableBlock() {
+            Iterator<Cursor> path = getCursor().getPathAsCursors();
+            Cursor parent = path.next();
+            while (path.hasNext()) {
+                Cursor cursor = path.next();
+                if (cursor.getValue() instanceof J.MethodDeclaration) {
+                    assert parent.getValue() instanceof J.Block : "Parent of method declaration is not a block. Was: " + parent.getValue();
+                    return parent;
                 }
+                if (cursor.getValue() instanceof J.Block && J.Block.isStaticOrInitBlock(cursor)) {
+                    return cursor;
+                }
+                parent = cursor;
             }
-            return null;
+            throw new IllegalStateException("Could not find outer executable block!");
         }
 
         private static boolean isSafePartialPathExpression(Expression expression) {

--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.security;
 
 import lombok.AllArgsConstructor;
+import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
@@ -95,22 +96,6 @@ public class PartialPathTraversalVulnerability extends Recipe {
                 .imports("java.nio.file.Paths")
                 .build();
 
-        @AllArgsConstructor
-        private static final class GetCanonicalPathToStartsWithLocalFlow extends LocalFlowSpec<J.MethodInvocation, Expression> {
-            Expression currentStartsWithSelect;
-            @Override
-            public boolean isSource(J.MethodInvocation source, Cursor cursor) {
-                // SOURCE: Any call to `File#getCanonicalPath()`
-                return getCanonicalPathMatcher.matches(source);
-            }
-
-            @Override
-            public boolean isSink(Expression sink, Cursor cursor) {
-                // SINK: Any J.Identifier that is the select (CodeQL: 'qualifier') of a call to `String#startsWith(String)`
-                return currentStartsWithSelect == sink;
-            }
-        }
-
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
             Cursor parentCursor = getCursor().dropParentUntil(SourceFile.class::isInstance);
@@ -152,23 +137,31 @@ public class PartialPathTraversalVulnerability extends Recipe {
                 );
             } else {
                 // Compute a set of potential alternative select statements
-                final Set<Expression> alternateSelects = computeAlternateSelects(select);
+                final Set<ExpressionWithTry> alternateSelects = computeAlternateSelects(select);
                 if (alternateSelects.size() == 1) {
-                    Expression alternateSelect = alternateSelects.iterator().next();
-                    J.MethodInvocation getCanonicalPathSelectReplacement = method.getSelect().withTemplate(
-                            toPathGetCanonicalFileTemplate,
-                            ((J.Identifier) select).getCoordinates().replace(),
-                            alternateSelect
-                    );
-                    return replaceWithPathStartsWithMethodInvocation(
-                            method,
-                            argument,
-                            getCanonicalPathSelectReplacement
-                    );
-                } else if (!alternateSelects.isEmpty()) {
-                    // There are multiple possible alternative selects.
+                    ExpressionWithTry expressionWithTry = alternateSelects.iterator().next();
+                    // If both the select statements share the same outer `try` block, then we can make a more
+                    // intelligent replacement
+                    if (expressionWithTry.maybeTryStatement == findNearestRelevantTry(getCursor())) {
+                        Expression alternateSelect = expressionWithTry.expression;
+                        J.MethodInvocation getCanonicalPathSelectReplacement = method.getSelect().withTemplate(
+                                toPathGetCanonicalFileTemplate,
+                                ((J.Identifier) select).getCoordinates().replace(),
+                                alternateSelect
+                        );
+                        return replaceWithPathStartsWithMethodInvocation(
+                                method,
+                                argument,
+                                getCanonicalPathSelectReplacement
+                        );
+                    }
+                    // Otherwise, we can't make a more intelligent replacement, fall back to the default
+                }
+                if (!alternateSelects.isEmpty()) {
+                    // There are multiple possible alternative selects,
+                    // or the alternative select does not share the same outer `try` block.
                     // This is a super complicated case.
-                    // The best solution is to simply wrap the subject in `new File(...)` and use that.
+                    // The best solution is to simply wrap the subject in `Paths.get(...).normalize()` and use that.
                     maybeAddImport("java.nio.file.Paths");
                     J.MethodInvocation newSelect = method.getSelect().withTemplate(
                             pathCreationNormalizeTemplate,
@@ -185,18 +178,58 @@ public class PartialPathTraversalVulnerability extends Recipe {
             return null;
         }
 
-        private Set<Expression> computeAlternateSelects(Expression currentSelect) {
+        @AllArgsConstructor
+        private static final class GetCanonicalPathToStartsWithLocalFlow extends LocalFlowSpec<J.MethodInvocation, Expression> {
+            Expression currentStartsWithSelect;
+
+            @Override
+            public boolean isSource(J.MethodInvocation source, Cursor cursor) {
+                // SOURCE: Any call to `File#getCanonicalPath()`
+                return getCanonicalPathMatcher.matches(source);
+            }
+
+            @Override
+            public boolean isSink(Expression sink, Cursor cursor) {
+                // SINK: Any J.Identifier that is the select (CodeQL: 'qualifier') of a call to `String#startsWith(String)`
+                return currentStartsWithSelect == sink;
+            }
+        }
+
+        @Value
+        static class ExpressionWithTry {
+            Expression expression;
+            @Nullable
+            J.Try maybeTryStatement;
+        }
+
+        @Nullable
+        private static J.Try findNearestRelevantTry(Cursor startCursor) {
+            for (Cursor cursor : (Iterable<Cursor>) startCursor::getPathAsCursors) {
+                Object cursorValue = cursor.getValue();
+                if (cursorValue instanceof J.Try) {
+                    return (J.Try) cursorValue;
+                }
+                if (cursorValue instanceof J.MethodDeclaration) {
+                    return null;
+                }
+                if (cursorValue instanceof J.Block && J.Block.isStaticOrInitBlock(cursor)) {
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        private Set<ExpressionWithTry> computeAlternateSelects(Expression currentSelect) {
             // Start visiting as high as possible.
             Cursor outerExecutable = findOuterExecutableBlock();
-            final Set<Expression> alternateSelects = new HashSet<>();
-            new JavaIsoVisitor<Set<Expression>>() {
+            final Set<ExpressionWithTry> alternateSelects = new HashSet<>();
+            new JavaIsoVisitor<Set<ExpressionWithTry>>() {
                 @Override
-                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Set<Expression> alternateSelectsInner) {
+                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Set<ExpressionWithTry> alternateSelectsInner) {
                     if (getCanonicalPathMatcher.matches(method)) {
                         dataflow().findSinks(new GetCanonicalPathToStartsWithLocalFlow(currentSelect)).ifPresent(sinkFlow -> {
-                            sinkFlow.getSinks().forEach(sink -> {
-                                alternateSelectsInner.add(sinkFlow.getSource().getSelect());
-                            });
+                            J.Try maybeOuterTryStatement = findNearestRelevantTry(getCursor());
+                            alternateSelectsInner.add(new ExpressionWithTry(sinkFlow.getSource().getSelect(), maybeOuterTryStatement));
                         });
                     }
                     return super.visitMethodInvocation(method, alternateSelectsInner);

--- a/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
@@ -732,7 +732,6 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
     )
 
     @Test
-    @Disabled("Data flow doesn't currently look up to the parent declaring block from the source")
     fun `getCanonicalPath as variable assignment inside of a try catch block`() = rewriteRun(
         java(
             """
@@ -752,10 +751,11 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
                     }
                 }
             }
-            """,
+            """.trimIndent(),
             """
             import java.io.File;
             import java.io.IOException;
+            import java.nio.file.Paths;
 
             class A {
                 void foo(File dir, File parent) {
@@ -765,12 +765,12 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
                     } catch (IOException e) {
                         throw new RuntimeException("Invalid directory: " + dir.getCanonicalPath());
                     }
-                    if (!canonicalPath.startsWith(parent.getCanonicalPath())) {
+                    if (!Paths.get(canonicalPath).normalize().startsWith(parent.getCanonicalFile().toPath())) {
                         throw new RuntimeException("Invalid directory: " + dir.getCanonicalPath());
                     }
                 }
             }
-            """
+            """.trimIndent()
         )
     )
 }


### PR DESCRIPTION
This improves the performance of this recipie by moving data flow computations out of the general recipie flow to visitors that are only executed when the `startsWith` method is encountered.

Also, fix the uncommon 'try' block case.
