### PR TITLE
Don't fix Partial Path Traversal if vuln is Zip Slip

### DIFF
--- a/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/PartialPathTraversalVulnerability.java
@@ -84,7 +84,20 @@ public class PartialPathTraversalVulnerability extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new PartialPathTraversalVulnerabilityVisitor<>();
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                J.CompilationUnit compilationUnit =
+                        (J.CompilationUnit) new ZipSlip.ZipSlipComplete<>(false, false)
+                                .visitNonNull(cu, executionContext, getCursor().getParentOrThrow());
+                if (cu != compilationUnit) {
+                    // The root cause of this vulnerability is Zip Slip, so don't run partial Path
+                    return cu;
+                }
+                return (J.CompilationUnit) new PartialPathTraversalVulnerabilityVisitor<ExecutionContext>()
+                        .visitNonNull(cu, executionContext, getCursor().getParentOrThrow());
+            }
+        };
     }
 
     static class PartialPathTraversalVulnerabilityVisitor<P> extends JavaIsoVisitor<P> {

--- a/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/security/PartialPathTraversalVulnerabilityTest.kt
@@ -673,7 +673,7 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
     )
 
     @Test
-    fun `getCanonicalPath startsWith string variable with File seperator appended`() = rewriteRun(
+    fun `getCanonicalPath startsWith string variable with File separator appended`() = rewriteRun(
         java(
             """
             import java.io.File;
@@ -806,6 +806,30 @@ class PartialPathTraversalVulnerabilityTest : RewriteTest {
                 }
             }
             """.trimIndent()
+        )
+    )
+
+    @Test
+    fun `does not fix when the vulnerability is Zip Slip`() = rewriteRun(
+        java(
+            """
+            import java.io.File;
+            import java.util.Enumeration;
+            import java.util.zip.ZipEntry;
+            import java.util.zip.ZipFile;
+            import java.io.FileOutputStream;
+
+            class A {
+                void zipSlip(File destination, ZipFile zip) {
+                    Enumeration<? extends ZipEntry> entries = zip.entries();
+                    while (entries.hasMoreElements()) {
+                        ZipEntry e = entries.nextElement();
+                        File f = new File(destination, e.getName());
+                        new FileOutputStream(f);
+                    }
+                }
+            }
+            """
         )
     )
 }


### PR DESCRIPTION
Only fix Partial Path is not Zip Slip. If the vulnerability involves
Zip Files, only fix it with Zip Slip
