### PR TITLE
SecureSnakeYamlConstructor: Increase Scope, decrease False Positives

### DIFF
--- a/src/main/java/org/openrewrite/java/security/marshalling/SecureSnakeYamlConstructor.java
+++ b/src/main/java/org/openrewrite/java/security/marshalling/SecureSnakeYamlConstructor.java
@@ -15,18 +15,26 @@
  */
 package org.openrewrite.java.security.marshalling;
 
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
-import org.openrewrite.java.JavaParser;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.*;
+import org.openrewrite.java.dataflow.internal.InvocationMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SecureSnakeYamlConstructor extends Recipe {
+    private static final MethodMatcher snakeYamlZeroArgumentConstructor = new MethodMatcher("org.yaml.snakeyaml.Yaml <constructor>()", true);
+    private static final MethodMatcher snakeYamlRepresenterArgumentConstructor = new MethodMatcher("org.yaml.snakeyaml.Yaml <constructor>(org.yaml.snakeyaml.representer.Representer)", true);
+    private static final MethodMatcher snakeYamlDumperArgumentConstructor = new MethodMatcher("org.yaml.snakeyaml.Yaml <constructor>(org.yaml.snakeyaml.DumperOptions)", true);
 
     @Override
     public String getDisplayName() {
@@ -45,11 +53,38 @@ public class SecureSnakeYamlConstructor extends Recipe {
 
     @Override
     protected JavaVisitor<ExecutionContext> getVisitor() {
-        MethodMatcher snakeYamlConstructor = new MethodMatcher("org.yaml.snakeyaml.Yaml <constructor>()", true);
+        InvocationMatcher yamlConstructor = InvocationMatcher.fromInvocationMatchers(
+                snakeYamlZeroArgumentConstructor,
+                snakeYamlRepresenterArgumentConstructor,
+                snakeYamlDumperArgumentConstructor
+        );
         return new JavaVisitor<ExecutionContext>() {
             @Override
+            public J visitMemberReference(J.MemberReference memberRef, ExecutionContext executionContext) {
+                if (snakeYamlZeroArgumentConstructor.matches(memberRef.getMethodType())) {
+                    maybeAddImport("org.yaml.snakeyaml.constructor.SafeConstructor");
+                    return memberRef.withTemplate(
+                            JavaTemplate
+                                    .builder(this::getCursor, "() -> new Yaml(new SafeConstructor())")
+                                    .imports("org.yaml.snakeyaml.Yaml")
+                                    .imports("org.yaml.snakeyaml.constructor.SafeConstructor")
+                                    .javaParser(() -> JavaParser.fromJavaVersion()
+                                            .classpath("snakeyaml")
+                                            .build())
+                                    .build(),
+                            memberRef.getCoordinates().replace()
+                    );
+                }
+                return super.visitMemberReference(memberRef, executionContext);
+            }
+
+            @Override
             public J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
-                if (snakeYamlConstructor.matches(newClass)) {
+                Cursor outerExecutableBlockCursor = getOuterMostExecutableBlock(getCursor());
+                if (outerExecutableBlockCursor != null && !isSnakeYamlUsedUnsafeOrEscapesScope(outerExecutableBlockCursor)) {
+                    return newClass;
+                }
+                if (snakeYamlZeroArgumentConstructor.matches(newClass)) {
                     JavaType.Method ctorType = newClass.getConstructorType();
                     assert ctorType != null;
 
@@ -65,10 +100,179 @@ public class SecureSnakeYamlConstructor extends Recipe {
                                     .build(),
                             newClass.getCoordinates().replace()
                     );
+                } else if (snakeYamlRepresenterArgumentConstructor.matches(newClass)) {
+                    JavaType.Method ctorType = newClass.getConstructorType();
+                    assert ctorType != null;
+
+                    maybeAddImport("org.yaml.snakeyaml.constructor.SafeConstructor");
+                    maybeAddImport("org.yaml.snakeyaml.DumperOptions");
+                    return newClass.withTemplate(
+                            JavaTemplate
+                                    .builder(this::getCursor, "new Yaml(new SafeConstructor(), #{any(org.yaml.snakeyaml.representer.Representer)}, new DumperOptions())")
+                                    .imports(
+                                            "org.yaml.snakeyaml.Yaml",
+                                            "org.yaml.snakeyaml.DumperOptions",
+                                            "org.yaml.snakeyaml.constructor.SafeConstructor",
+                                            "org.yaml.snakeyaml.representer.Representer"
+                                    )
+                                    .javaParser(() -> JavaParser.fromJavaVersion()
+                                            .classpath("snakeyaml")
+                                            .build())
+                                    .build(),
+                            newClass.getCoordinates().replace(),
+                            newClass.getArguments().get(0)
+                    );
+                } else if (snakeYamlDumperArgumentConstructor.matches(newClass)) {
+                    JavaType.Method ctorType = newClass.getConstructorType();
+                    assert ctorType != null;
+
+                    maybeAddImport("org.yaml.snakeyaml.constructor.SafeConstructor");
+                    maybeAddImport("org.yaml.snakeyaml.representer.Representer");
+                    return newClass.withTemplate(
+                            JavaTemplate
+                                    .builder(this::getCursor, "new Yaml(new SafeConstructor(), new Representer(), #{any(org.yaml.snakeyaml.DumperOptions)})")
+                                    .imports(
+                                            "org.yaml.snakeyaml.Yaml",
+                                            "org.yaml.snakeyaml.DumperOptions",
+                                            "org.yaml.snakeyaml.constructor.SafeConstructor",
+                                            "org.yaml.snakeyaml.representer.Representer"
+                                    )
+                                    .javaParser(() -> JavaParser.fromJavaVersion()
+                                            .classpath("snakeyaml")
+                                            .build())
+                                    .build(),
+                            newClass.getCoordinates().replace(),
+                            newClass.getArguments().get(0)
+                    );
                 }
 
                 return super.visitNewClass(newClass, ctx);
             }
         };
+    }
+
+    /**
+     * The {@link J.Block} that is passed should either be an init block, static block, or the body of a method.
+     *
+     * @return true if some instance of a <code>Yaml</code> class is created in the block, and that instance is used in an unsafe way,
+     * or if it 'escapes' the scope of the block by being assigned to a variable outside the scope, passed as an argument, or returned.
+     */
+    private static boolean isSnakeYamlUsedUnsafeOrEscapesScope(Cursor scope) {
+        J.Block block = (J.Block) scope.getValue();
+
+        // The method arguments, if any are present. Not relevant in the scope of a static or init block.
+        Set<String> methodArguments = new HashSet<>();
+        Cursor maybeMethodDeclaration = scope.getParentOrThrow();
+        if (maybeMethodDeclaration.getValue() instanceof J.MethodDeclaration) {
+            J.MethodDeclaration methodDeclaration = maybeMethodDeclaration.getValue();
+            methodDeclaration
+                    .getParameters()
+                    .stream()
+                    .filter(p -> p instanceof J.VariableDeclarations)
+                    .flatMap(p -> ((J.VariableDeclarations) p).getVariables().stream())
+                    .forEach(v -> methodArguments.add(v.getSimpleName()));
+        }
+
+        AtomicBoolean isUnsafe = new AtomicBoolean(false);
+        new JavaIsoVisitor<AtomicBoolean>() {
+            final Stack<Set<String>> variablesDeclaredInScope;
+
+            {
+                variablesDeclaredInScope = new Stack<>();
+                variablesDeclaredInScope.push(methodArguments);
+            }
+
+            boolean isVariableInScope(String name) {
+                return variablesDeclaredInScope
+                        .stream()
+                        .flatMap(Set::stream)
+                        .anyMatch(name::equals);
+            }
+
+            @Override
+            public J.Block visitBlock(J.Block block, AtomicBoolean atomicBoolean) {
+                // short circuit if we've already determined that the block is unsafe
+                if (atomicBoolean.get()) {
+                    return block;
+                }
+                // otherwise, visit the block normally
+                // if we find a variable declaration, add it to the set of variables declared in the current scope
+                variablesDeclaredInScope.push(new HashSet<>());
+                J.Block b = super.visitBlock(block, atomicBoolean);
+                // once we've visited the block, remove the set of variables declared in the current scope
+                variablesDeclaredInScope.pop();
+                return b;
+            }
+
+            @Override
+            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, AtomicBoolean atomicBoolean) {
+                J.VariableDeclarations.NamedVariable v = super.visitVariable(variable, atomicBoolean);
+                // add the variable to the set of variables declared in the current scope
+                variablesDeclaredInScope.peek().add(v.getSimpleName());
+                return v;
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean atomicBoolean) {
+                if (method.getSelect() != null &&
+                        isSnakeYamlType(method.getSelect().getType()) &&
+                        method.getName().getSimpleName().startsWith("load")) {
+                    atomicBoolean.set(true);
+                    return method;
+                }
+                if (method.getArguments().stream().anyMatch(arg -> isSnakeYamlType(arg.getType()))) {
+                    atomicBoolean.set(true);
+                    return method;
+                }
+                return super.visitMethodInvocation(method, atomicBoolean);
+            }
+
+            @Override
+            public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean atomicBoolean) {
+                if (isSnakeYamlType(assignment.getAssignment().getType()) &&
+                        (assignment.getVariable() instanceof J.Identifier &&
+                                !isVariableInScope(((J.Identifier) assignment.getVariable()).getSimpleName())) ||
+                        !(assignment.getVariable() instanceof J.Identifier)) {
+                    atomicBoolean.set(true);
+                    return assignment;
+                }
+                return super.visitAssignment(assignment, atomicBoolean);
+            }
+
+            @Override
+            public J.Return visitReturn(J.Return _return, AtomicBoolean atomicBoolean) {
+                if (_return.getExpression() != null && isSnakeYamlType(_return.getExpression().getType())) {
+                    atomicBoolean.set(true);
+                    return _return;
+                }
+                return super.visitReturn(_return, atomicBoolean);
+            }
+
+            private boolean isSnakeYamlType(@Nullable JavaType type) {
+                return TypeUtils.isAssignableTo("org.yaml.snakeyaml.Yaml", type);
+            }
+        }.visit(block, isUnsafe, scope.getParentOrThrow());
+        return isUnsafe.get();
+    }
+
+    @Nullable
+    private static Cursor getOuterMostExecutableBlock(Cursor startCursor) {
+        Cursor blockCursor = null;
+        for (Cursor cursor : (Iterable<Cursor>) startCursor::getPathAsCursors) {
+            Object cursorValue = cursor.getValue();
+            if (cursorValue instanceof J.Block) {
+                if (J.Block.isStaticOrInitBlock(cursor)) {
+                    return cursor;
+                }
+                blockCursor = cursor;
+            }
+            if (cursorValue instanceof J.ClassDeclaration) {
+                return null;
+            }
+            if (cursorValue instanceof J.MethodDeclaration) {
+                return blockCursor;
+            }
+        }
+        return null;
     }
 }

--- a/src/test/java/org/openrewrite/java/security/marshalling/SecureSnakeYamlConstructorTest.java
+++ b/src/test/java/org/openrewrite/java/security/marshalling/SecureSnakeYamlConstructorTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.security.marshalling;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -49,6 +50,316 @@ class SecureSnakeYamlConstructorTest implements RewriteTest {
                   class Test {
                       Object o = new Yaml(new SafeConstructor());
                   }
+              """
+          )
+        );
+    }
+
+    @Test
+    void snakeYamlWithDumperArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+                  import org.yaml.snakeyaml.Yaml;
+                  import org.yaml.snakeyaml.DumperOptions;
+                  
+                  class Test {
+                      Object o = new Yaml(new DumperOptions());
+                  }
+              """,
+            """
+                  import org.yaml.snakeyaml.Yaml;
+                  import org.yaml.snakeyaml.constructor.SafeConstructor;
+                  import org.yaml.snakeyaml.representer.Representer;
+                  import org.yaml.snakeyaml.DumperOptions;
+                  
+                  class Test {
+                      Object o = new Yaml(new SafeConstructor(), new Representer(), new DumperOptions());
+                  }
+              """
+          )
+        );
+    }
+
+    @Test
+    void snakeYamlWithRepresenterArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+                  import org.yaml.snakeyaml.Yaml;
+                  import org.yaml.snakeyaml.representer.Representer;
+                  
+                  class Test {
+                      Object o = new Yaml(new Representer());
+                  }
+              """,
+            """
+                  import org.yaml.snakeyaml.DumperOptions;
+                  import org.yaml.snakeyaml.Yaml;
+                  import org.yaml.snakeyaml.constructor.SafeConstructor;
+                  import org.yaml.snakeyaml.representer.Representer;
+                  
+                  class Test {
+                      Object o = new Yaml(new SafeConstructor(), new Representer(), new DumperOptions());
+                  }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotFixYamlIfDumpIsOnlyMethodCalled() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+                  import org.yaml.snakeyaml.Yaml;
+                  
+                  class Test {
+                      String test(Object o) {
+                         Yaml y = new Yaml();
+                         return y.dump(o);
+                      }
+                  }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doFixYamlIfLoadIsOnlyMethodCalled() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.yaml.snakeyaml.Yaml;
+                            
+              class Test {
+                  Object test(String o) {
+                      Yaml y = new Yaml();
+                      return y.load(o);
+                  }
+              }
+              """,
+            """
+              import org.yaml.snakeyaml.Yaml;
+              import org.yaml.snakeyaml.constructor.SafeConstructor;
+                            
+              class Test {
+                  Object test(String o) {
+                      Yaml y = new Yaml(new SafeConstructor());
+                      return y.load(o);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doFixYamlIfYamlPassedAsArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.yaml.snakeyaml.Yaml;
+                            
+              class Test {
+                  void test(String o) {
+                      Yaml y = new Yaml();
+                      doSomething(y);
+                  }
+                  
+                  void doSomething(Yaml y) {
+                      // no-op
+                  }
+              }
+              """,
+            """
+              import org.yaml.snakeyaml.Yaml;
+              import org.yaml.snakeyaml.constructor.SafeConstructor;
+                            
+              class Test {
+                  void test(String o) {
+                      Yaml y = new Yaml(new SafeConstructor());
+                      doSomething(y);
+                  }
+                  
+                  void doSomething(Yaml y) {
+                      // no-op
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doFixYamlIfYamlAssignedToClassVariable() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.yaml.snakeyaml.Yaml;
+                            
+              class Test {
+                  final Yaml y;
+                  Test(Object o) {
+                      y = new Yaml();
+                  }
+              }
+              """,
+            """
+              import org.yaml.snakeyaml.Yaml;
+              import org.yaml.snakeyaml.constructor.SafeConstructor;
+                            
+              class Test {
+                  final Yaml y;
+                  Test(Object o) {
+                      y = new Yaml(new SafeConstructor());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"UnusedAssignment", "ParameterCanBeLocal"})
+    void doNotFixYamlIfYamlAssignedToConstructorVariable() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.yaml.snakeyaml.Yaml;
+                            
+              class Test {
+                  final Object y;
+                  Test(Object y) {
+                      y = new Yaml();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"UnusedAssignment"})
+    void doNotFixYamlIfYamlAssignedToMethodScopeVariable() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.yaml.snakeyaml.Yaml;
+                            
+              class Test {
+                  final Object y;
+                  Test() {
+                      Object y;
+                      {
+                        y = new Yaml();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doFixYamlIfYamlAssignedToClassVariableViaThis() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.yaml.snakeyaml.Yaml;
+                            
+              class Test {
+                  final Yaml y;
+                  Test(Object o) {
+                      this.y = new Yaml();
+                  }
+              }
+              """,
+            """
+              import org.yaml.snakeyaml.Yaml;
+              import org.yaml.snakeyaml.constructor.SafeConstructor;
+                            
+              class Test {
+                  final Yaml y;
+                  Test(Object o) {
+                      this.y = new Yaml(new SafeConstructor());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doFixYamlIfSnakeYamlIsReturned() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.yaml.snakeyaml.Yaml;
+                            
+              class Test {
+                  Yaml test() {
+                      return new Yaml();
+                  }
+              }
+              """,
+            """
+              import org.yaml.snakeyaml.Yaml;
+              import org.yaml.snakeyaml.constructor.SafeConstructor;
+                            
+              class Test {
+                  Yaml test() {
+                      return new Yaml(new SafeConstructor());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Disabled("See: https://github.com/openrewrite/rewrite/issues/2540")
+    void doFixYamlIfPassedInLambda() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.yaml.snakeyaml.Yaml;
+              import java.util.function.Supplier;
+                            
+              class Test {
+                  void test() {
+                      supply(Yaml::new);
+                  }
+                  
+                  void supply(Supplier<Yaml> supplier) {
+                      // no-op
+                  }
+              }
+              """,
+            """
+              import org.yaml.snakeyaml.Yaml;
+              import org.yaml.snakeyaml.constructor.SafeConstructor;
+                            
+              class Test {
+                  void test() {
+                      supply(() -> new Yaml(new SafeConstructor()));
+                  }
+                  
+                  void supply(Supplier<Yaml> supplier) {
+                      // no-op
+                  }
+              }
               """
           )
         );


### PR DESCRIPTION
`new Yaml()` will now only be fixed if somewhere in scope `load*` is called on a `Yaml` instance,
or if an instance of a `yaml` object escapes the scope of the method the constructor was called.

This way, if the `Yaml` instance is just being used to dump an object to YAML, it won't be flagged/fixed.
