### PR TITLE
fix: correct CsrfProtection recipe applicable test

### DIFF
--- a/src/main/java/org/openrewrite/java/security/spring/CsrfProtection.java
+++ b/src/main/java/org/openrewrite/java/security/spring/CsrfProtection.java
@@ -55,7 +55,7 @@ public class CsrfProtection extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
-        return new HasTypeOnClasspathSourceSet<>("org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter");
+        return new UsesType<>("org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter");
     }
 
     private static final MethodMatcher CSRF = new MethodMatcher("org.springframework.security.config.annotation.web.builders.HttpSecurity csrf()");

--- a/src/main/java/org/openrewrite/java/security/spring/CsrfProtection.java
+++ b/src/main/java/org/openrewrite/java/security/spring/CsrfProtection.java
@@ -54,13 +54,8 @@ public class CsrfProtection extends Recipe {
     }
 
     @Override
-    protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
-        return new HasTypeOnClasspathSourceSet<>("org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter");
-    }
-
-    @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
-        return new UsesType<>("org.springframework.security.web.csrf.CookieCsrfTokenRepository");
+        return new HasTypeOnClasspathSourceSet<>("org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter");
     }
 
     private static final MethodMatcher CSRF = new MethodMatcher("org.springframework.security.config.annotation.web.builders.HttpSecurity csrf()");


### PR DESCRIPTION
Correct recipe `CsrfProtection` 's applicable test.

```
    @Override
    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
        return new UsesType<>("org.springframework.security.web.csrf.CookieCsrfTokenRepository");
    }
```
this is before, seems not correct, since `CookieCsrfTokenRepository` is what the recipe is going to add. see [the test](https://github.com/openrewrite/rewrite-java-security/blob/923dfca712e203e68006a99f363cff5d698a7cd7/src/test/java/org/openrewrite/java/security/spring/CsrfProtectionTest.java#L75) here.
