### PR TITLE
Fixed duplicate allow-list generation

### DIFF
--- a/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
@@ -208,7 +208,7 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
         private final XmlParserXXEVulnerability.ExternalDTDs acc;
 
         private final boolean generateAllowList;
-
+        private final String xmlFactoryVariableName;
 
         XmlFactoryInsertPropertyStatementVisitor(
                 J.Block scope,
@@ -222,17 +222,19 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
         ) {
             this.scope = scope;
             this.acc = acc;
+            this.xmlFactoryVariableName = factoryVariableName;
+
             if (needsExternalEntitiesDisabled) {
-                propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);");
+                propertyTemplate.append(xmlFactoryVariableName).append(".setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);");
             }
             if (needsSupportDTDFalse && accIsEmpty) {
                 if (needsSupportDTDTrue) {
-                    propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, false);");
+                    propertyTemplate.append(xmlFactoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, false);");
                 }
             }
             if (needsSupportDTDFalse && !accIsEmpty) {
                 if (needsResolverMethod && needsSupportDTDTrue) {
-                    propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, true);");
+                    propertyTemplate.append(xmlFactoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, true);");
                 }
                 this.generateAllowList = needsResolverMethod;
             } else if (!needsSupportDTDTrue && !accIsEmpty) {
@@ -243,7 +245,6 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
         }
 
         private Set<String> addAllowList(boolean generateAllowList) {
-
             Set<String> imports = new HashSet<>();
             if (acc.externalDTDs.isEmpty() || !generateAllowList) {
                 return Collections.emptySet();
@@ -254,20 +255,16 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                     getCursor(),
                     VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER
             );
+            imports.add("java.util.Collection");
+            imports.add("javax.xml.stream.XMLStreamException");
 
             if (acc.externalDTDs.size() > 1) {
-                imports.add("java.util.Collection");
                 imports.add("java.util.Arrays");
-                imports.add("javax.xml.stream.XMLStreamException");
-
                 propertyTemplate.append(
                         "Collection<String>" + newAllowListVariableName + " = Arrays.asList(\n"
                 );
             } else {
-                imports.add("java.util.Collection");
                 imports.add("java.util.Collections");
-                imports.add("javax.xml.stream.XMLStreamException");
-
                 propertyTemplate.append(
                         "Collection<String>" + newAllowListVariableName + " = Collections.singleton(\n"
                 );
@@ -279,8 +276,8 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                     ""
             ));
             propertyTemplate.append(allowListContent).append("\n);\n");
-            propertyTemplate.append(
-                    "f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {\n" +
+            propertyTemplate.append(xmlFactoryVariableName).append(
+                    ".setXMLResolver((publicID, systemID, baseURI, namespace) -> {\n" +
                             "   if (" + newAllowListVariableName + ".contains(systemID)){\n" +
                             "       // returning null will cause the parser to resolve the entity\n" +
                             "       return null;\n" +

--- a/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
@@ -34,6 +34,9 @@ import java.util.stream.Collectors;
 
 
 public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulnerability.ExternalDTDs> {
+
+    private static final String PUBLIC_ID_STRING = "PUBLIC";
+    private static final String SYSTEM_ID_STRING = "SYSTEM";
     private static final MethodMatcher XML_PARSER_FACTORY_INSTANCE = new MethodMatcher("javax.xml.stream.XMLInputFactory new*()");
     private static final MethodMatcher XML_PARSER_FACTORY_SET_PROPERTY = new MethodMatcher("javax.xml.stream.XMLInputFactory setProperty(java.lang.String, ..)");
 
@@ -41,13 +44,26 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
 
     private static final String XML_FACTORY_FQN = "javax.xml.stream.XMLInputFactory";
     private static final String SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME = "IS_SUPPORTING_EXTERNAL_ENTITIES";
-    private static final String SUPPORT_DTD_PROPERTY_NAME = "SUPPORT_DTD";
+    private static final String SUPPORT_DTD_FALSE_PROPERTY_NAME = "SUPPORT_DTD";
+
+    private static final String SUPPORT_DTD_TRUE_PROPERTY_NAME = "SUPPORT_DTD_TRUE";
     private static final String XML_PARSER_INITIALIZATION_METHOD = "xml-parser-initialization-method";
     private static final String XML_FACTORY_VARIABLE_NAME = "xml-factory-variable-name";
 
     private static final String XML_RESOLVER_METHOD = "xml-resolver-initialization-method";
 
-    public static class ExternalDTDs {
+    static String extractURLFromEntity(String identName) {
+        if (identName.contains(PUBLIC_ID_STRING)) {
+            String[] lines = identName.split("\\r?\\n|\\r");
+            String dtdPath = lines[lines.length - 1].trim();
+            dtdPath = dtdPath.split("\"")[1];
+            return dtdPath;
+        } else {
+            return identName.split("\"")[1];
+        }
+    }
+
+    public static final class ExternalDTDs {
         Set<String> externalDTDs = new CopyOnWriteArraySet<>();
     }
 
@@ -69,26 +85,26 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(ExternalDTDs acc) {
 
+
         return new XmlIsoVisitor<ExecutionContext>() {
             @Override
             public Xml.DocTypeDecl visitDocTypeDecl(Xml.DocTypeDecl docTypeDecl, ExecutionContext executionContext) {
-                // Write tests for checking what is included in getExternalSubsets().
                 if (docTypeDecl.getExternalSubsets() != null) {
                     for (Xml.Element element : docTypeDecl.getExternalSubsets().getElements()) {
                         for (Xml.Ident ident : element.getSubset()) {
-                            String dtdPath = ident.getName().split("\"")[1];
-                            acc.externalDTDs.add(dtdPath);
+                            acc.externalDTDs.add(extractURLFromEntity(ident.getName()));
                         }
                     }
                 }
-                if (docTypeDecl.getInternalSubset() != null){
-                    if (!docTypeDecl.getInternalSubset().isEmpty()){
-                        for (Xml.Ident ident : docTypeDecl.getInternalSubset()) {
-//                            acc.externalDTDs.add(docTypeDecl.getInternalSubset().get(1).getName().replace("\"", ""));
-                            acc.externalDTDs.add(ident.getName().replace("\"", ""));
+                if (docTypeDecl.getInternalSubset() != null) {
+                    if (!docTypeDecl.getInternalSubset().isEmpty()) {
+                        if (docTypeDecl.getExternalId() != null) {
+                            if ("PUBLIC".equals(docTypeDecl.getExternalId().getName()) && docTypeDecl.getInternalSubset().size() > 1) {
+                                acc.externalDTDs.add(docTypeDecl.getInternalSubset().get(1).getName().replace("\"", ""));
+                            } else if ("SYSTEM".equals(docTypeDecl.getExternalId().getName())) {
+                                acc.externalDTDs.add(docTypeDecl.getInternalSubset().get(0).getName().replace("\"", ""));
+                            }
                         }
-
-                        System.out.println("CAUGHT IT");
                     }
                 }
 
@@ -107,29 +123,31 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
 
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
                 Cursor supportsExternalCursor = getCursor().getMessage(SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME);
-                Cursor supportsDTDCursor = getCursor().getMessage(SUPPORT_DTD_PROPERTY_NAME);
+                Cursor supportsFalseDTDCursor = getCursor().getMessage(SUPPORT_DTD_FALSE_PROPERTY_NAME);
+                Cursor supportsDTDTrueCursor = getCursor().getMessage(SUPPORT_DTD_TRUE_PROPERTY_NAME);
                 Cursor initializationCursor = getCursor().getMessage(XML_PARSER_INITIALIZATION_METHOD);
                 String xmlFactoryVariableName = getCursor().getMessage(XML_FACTORY_VARIABLE_NAME);
                 Cursor xmlResolverMethod = getCursor().getMessage(XML_RESOLVER_METHOD);
 
                 Cursor setPropertyBlockCursor = null;
-                if (supportsExternalCursor == null && supportsDTDCursor == null) {
+                if (supportsExternalCursor == null && supportsFalseDTDCursor == null) {
                     setPropertyBlockCursor = initializationCursor;
-                } else if (supportsExternalCursor == null ^ supportsDTDCursor == null) {
-                    setPropertyBlockCursor = supportsExternalCursor == null ? supportsDTDCursor : supportsExternalCursor;
+
+                } else if (supportsExternalCursor == null ^ supportsFalseDTDCursor == null) {
+                    setPropertyBlockCursor = supportsExternalCursor == null ? supportsFalseDTDCursor : supportsExternalCursor;
                 }
                 if (setPropertyBlockCursor != null && xmlFactoryVariableName != null) {
                     doAfterVisit(new XmlFactoryInsertPropertyStatementVisitor(
                             setPropertyBlockCursor.getValue(),
                             xmlFactoryVariableName,
                             supportsExternalCursor == null,
-                            supportsDTDCursor == null && acc.externalDTDs.isEmpty(),
+                            supportsFalseDTDCursor == null,
+                            acc.externalDTDs.isEmpty(),
+                            supportsDTDTrueCursor == null,
                             xmlResolverMethod == null,
                             acc
                     ));
                 }
-            // if xmlresolver method exists (so not null), don't insert a new one.
-
                 return cd;
             }
 
@@ -151,77 +169,110 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                     J.FieldAccess fa = (J.FieldAccess) m.getArguments().get(0);
                     if (SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME.equals(fa.getSimpleName())) {
                         getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
-                    } else if (SUPPORT_DTD_PROPERTY_NAME.equals(fa.getSimpleName())) {
-                        getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORT_DTD_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
+                    } else if (SUPPORT_DTD_FALSE_PROPERTY_NAME.equals(fa.getSimpleName())) {
+                        checkDTDSupport(m);
                     }
                 } else if (XML_PARSER_FACTORY_SET_PROPERTY.matches(m) && m.getArguments().get(0) instanceof J.Literal) {
                     J.Literal literal = (J.Literal) m.getArguments().get(0);
-                    if (TypeUtils.isOfClassType(literal.getType(), "String")) {
+                    if (TypeUtils.isString(literal.getType())) {
                         if (XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES.equals(literal.getValue())) {
                             getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
                         } else if (XMLInputFactory.SUPPORT_DTD.equals(literal.getValue())) {
-                            getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORT_DTD_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
+                            checkDTDSupport(m);
                         }
                     }
                 } else if (XML_PARSER_FACTORY_SET_RESOLVER.matches(m)) {
                     getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, XML_RESOLVER_METHOD, getCursor().dropParentUntil((J.Block.class::isInstance)));
                 }
                 return m;
+
+
+            }
+
+            private void checkDTDSupport(J.MethodInvocation m) {
+                if (m.getArguments().get(1) instanceof J.Literal) {
+                    J.Literal literal = (J.Literal) m.getArguments().get(1);
+                    if (Boolean.TRUE.equals(literal.getValue())) {
+                        getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORT_DTD_TRUE_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
+                    } else {
+                        getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORT_DTD_FALSE_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
+                    }
+                }
             }
         });
     }
 
     private static class XmlFactoryInsertPropertyStatementVisitor extends JavaIsoVisitor<ExecutionContext> {
-        J.Block scope;
-        StringBuilder propertyTemplate = new StringBuilder();
-        ExternalDTDs acc;
+        private final J.Block scope;
+        private final StringBuilder propertyTemplate = new StringBuilder();
+        private final XmlParserXXEVulnerability.ExternalDTDs acc;
 
-        public XmlFactoryInsertPropertyStatementVisitor(
+        private final boolean generateAllowList;
+
+
+        XmlFactoryInsertPropertyStatementVisitor(
                 J.Block scope,
                 String factoryVariableName,
                 boolean needsExternalEntitiesDisabled,
-                boolean needsSupportsDtdDisabled,
+                boolean needsSupportDTDFalse,
+                boolean accIsEmpty,
+                boolean needsSupportDTDTrue,
                 boolean needsResolverMethod,
-                ExternalDTDs acc
+                XmlParserXXEVulnerability.ExternalDTDs acc
         ) {
             this.scope = scope;
             this.acc = acc;
             if (needsExternalEntitiesDisabled) {
                 propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);");
             }
-            if (needsSupportsDtdDisabled) {
-                propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, false);");
+            if (needsSupportDTDFalse && accIsEmpty) {
+                if (needsSupportDTDTrue) {
+                    propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, false);");
+                }
             }
-            if (!acc.externalDTDs.isEmpty()){
-                propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, true);");
-            }
-            if (!acc.externalDTDs.isEmpty()){
-                if (needsResolverMethod){
+            if (needsSupportDTDFalse && !accIsEmpty) {
+                if (needsResolverMethod && needsSupportDTDTrue) {
                     propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, true);");
                 }
+                this.generateAllowList = needsResolverMethod;
+            } else if (!needsSupportDTDTrue && !accIsEmpty) {
+                this.generateAllowList = needsResolverMethod;
+            } else {
+                this.generateAllowList = false;
             }
         }
 
-        private Set<String> addAllowList(){
-            if (acc.externalDTDs.isEmpty()){
+        private Set<String> addAllowList(boolean generateAllowList) {
+
+            Set<String> imports = new HashSet<>();
+            if (acc.externalDTDs.isEmpty() || !generateAllowList) {
                 return Collections.emptySet();
             }
-            if (acc.externalDTDs.size() > 1){
-
-            }
-            Set<String> imports = new HashSet<>();
-            imports.add("java.util.Collection");
-            imports.add("java.util.Collections");
-            imports.add("javax.xml.stream.XMLStreamException");
 
             String newAllowListVariableName = VariableNameUtils.generateVariableName(
                     "allowList",
                     getCursor(),
                     VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER
             );
-            propertyTemplate.append(
-                    "Collection<String>" + newAllowListVariableName + " = Collections.singleton(\n"
-            );
+
+            if (acc.externalDTDs.size() > 1) {
+                imports.add("java.util.Collection");
+                imports.add("java.util.Arrays");
+                imports.add("javax.xml.stream.XMLStreamException");
+
+                propertyTemplate.append(
+                        "Collection<String>" + newAllowListVariableName + " = Arrays.asList(\n"
+                );
+            } else {
+                imports.add("java.util.Collection");
+                imports.add("java.util.Collections");
+                imports.add("javax.xml.stream.XMLStreamException");
+
+                propertyTemplate.append(
+                        "Collection<String>" + newAllowListVariableName + " = Collections.singleton(\n"
+                );
+            }
+
             String allowListContent = acc.externalDTDs.stream().map(dtd -> '"' + dtd + '"').collect(Collectors.joining(
                     ",\n\t",
                     "\t",
@@ -230,13 +281,13 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
             propertyTemplate.append(allowListContent).append("\n);\n");
             propertyTemplate.append(
                     "f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {\n" +
-                    "   if (" + newAllowListVariableName + ".contains(systemID)){\n" +
-                    "       return null;\n" +
-                    "   }\n" +
-                    "   throw new XMLStreamException(\"Loading of DTD was blocked to prevent XXE: \" + systemID);\n" +
-                    "});"
+                            "   if (" + newAllowListVariableName + ".contains(systemID)){\n" +
+                            "       // returning null will cause the parser to resolve the entity\n" +
+                            "       return null;\n" +
+                            "   }\n" +
+                            "   throw new XMLStreamException(\"Loading of DTD was blocked to prevent XXE: \" + systemID);\n" +
+                            "});"
             );
-
             return imports;
         }
 
@@ -263,7 +314,8 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                         }
                     }
                 }
-//                Set<String> imports = addAllowList();
+
+                Set<String> imports = addAllowList(generateAllowList);
 
                 if (getCursor().getParent() != null && getCursor().getParent().getValue() instanceof J.ClassDeclaration) {
                     propertyTemplate.insert(0, "{\n").append("}");
@@ -277,7 +329,7 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                         .contextSensitive()
                         .build()
                         .apply(new Cursor(getCursor().getParent(), b), insertCoordinates);
-                if (b != block){
+                if (b != block) {
                     imports.forEach(this::maybeAddImport);
                 }
             }

--- a/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
@@ -32,15 +32,20 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 
+
 public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulnerability.ExternalDTDs> {
     private static final MethodMatcher XML_PARSER_FACTORY_INSTANCE = new MethodMatcher("javax.xml.stream.XMLInputFactory new*()");
     private static final MethodMatcher XML_PARSER_FACTORY_SET_PROPERTY = new MethodMatcher("javax.xml.stream.XMLInputFactory setProperty(java.lang.String, ..)");
+
+    private static final MethodMatcher XML_PARSER_FACTORY_SET_RESOLVER = new MethodMatcher("javax.xml.stream.XMLInputFactory setXMLResolver(javax.xml.stream.XMLResolver)");
 
     private static final String XML_FACTORY_FQN = "javax.xml.stream.XMLInputFactory";
     private static final String SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME = "IS_SUPPORTING_EXTERNAL_ENTITIES";
     private static final String SUPPORT_DTD_PROPERTY_NAME = "SUPPORT_DTD";
     private static final String XML_PARSER_INITIALIZATION_METHOD = "xml-parser-initialization-method";
     private static final String XML_FACTORY_VARIABLE_NAME = "xml-factory-variable-name";
+
+    private static final String XML_RESOLVER_METHOD = "xml-resolver-initialization-method";
 
     public static class ExternalDTDs {
         Set<String> externalDTDs = new CopyOnWriteArraySet<>();
@@ -76,24 +81,36 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                         }
                     }
                 }
-                if (!docTypeDecl.getInternalSubset().isEmpty()){
-                    acc.externalDTDs.add(docTypeDecl.getInternalSubset().get(1).getName().replace("\"", ""));
+                if (docTypeDecl.getInternalSubset() != null){
+                    if (!docTypeDecl.getInternalSubset().isEmpty()){
+                        for (Xml.Ident ident : docTypeDecl.getInternalSubset()) {
+//                            acc.externalDTDs.add(docTypeDecl.getInternalSubset().get(1).getName().replace("\"", ""));
+                            acc.externalDTDs.add(ident.getName().replace("\"", ""));
+                        }
+
+                        System.out.println("CAUGHT IT");
+                    }
                 }
+
                 return super.visitDocTypeDecl(docTypeDecl, executionContext);
             }
         };
     }
 
+    //q: What is Java doc format?
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(ExternalDTDs acc) {
+
         return Preconditions.check(new UsesType<>(XML_FACTORY_FQN, true), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
                 Cursor supportsExternalCursor = getCursor().getMessage(SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME);
                 Cursor supportsDTDCursor = getCursor().getMessage(SUPPORT_DTD_PROPERTY_NAME);
                 Cursor initializationCursor = getCursor().getMessage(XML_PARSER_INITIALIZATION_METHOD);
                 String xmlFactoryVariableName = getCursor().getMessage(XML_FACTORY_VARIABLE_NAME);
+                Cursor xmlResolverMethod = getCursor().getMessage(XML_RESOLVER_METHOD);
 
                 Cursor setPropertyBlockCursor = null;
                 if (supportsExternalCursor == null && supportsDTDCursor == null) {
@@ -107,9 +124,12 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                             xmlFactoryVariableName,
                             supportsExternalCursor == null,
                             supportsDTDCursor == null && acc.externalDTDs.isEmpty(),
+                            xmlResolverMethod == null,
                             acc
                     ));
                 }
+            // if xmlresolver method exists (so not null), don't insert a new one.
+
                 return cd;
             }
 
@@ -143,6 +163,8 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                             getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORT_DTD_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
                         }
                     }
+                } else if (XML_PARSER_FACTORY_SET_RESOLVER.matches(m)) {
+                    getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, XML_RESOLVER_METHOD, getCursor().dropParentUntil((J.Block.class::isInstance)));
                 }
                 return m;
             }
@@ -159,6 +181,7 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                 String factoryVariableName,
                 boolean needsExternalEntitiesDisabled,
                 boolean needsSupportsDtdDisabled,
+                boolean needsResolverMethod,
                 ExternalDTDs acc
         ) {
             this.scope = scope;
@@ -171,13 +194,20 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
             }
             if (!acc.externalDTDs.isEmpty()){
                 propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, true);");
-
+            }
+            if (!acc.externalDTDs.isEmpty()){
+                if (needsResolverMethod){
+                    propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, true);");
+                }
             }
         }
 
         private Set<String> addAllowList(){
             if (acc.externalDTDs.isEmpty()){
                 return Collections.emptySet();
+            }
+            if (acc.externalDTDs.size() > 1){
+
             }
             Set<String> imports = new HashSet<>();
             imports.add("java.util.Collection");
@@ -233,7 +263,7 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulner
                         }
                     }
                 }
-                Set<String> imports = addAllowList();
+//                Set<String> imports = addAllowList();
 
                 if (getCursor().getParent() != null && getCursor().getParent().getValue() instanceof J.ClassDeclaration) {
                     propertyTemplate.insert(0, "{\n").append("}");

--- a/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
@@ -19,13 +19,20 @@ import org.openrewrite.*;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.VariableNameUtils;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaCoordinates;
-import org.openrewrite.java.tree.Statement;
-import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.xml.XmlIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
 
-public class XmlParserXXEVulnerability extends Recipe {
+import javax.xml.stream.XMLInputFactory;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Collectors;
+
+public class XmlParserXXEVulnerability extends ScanningRecipe<XmlParserXXEVulnerability.ExternalDTDs> {
     private static final MethodMatcher XML_PARSER_FACTORY_INSTANCE = new MethodMatcher("javax.xml.stream.XMLInputFactory new*()");
     private static final MethodMatcher XML_PARSER_FACTORY_SET_PROPERTY = new MethodMatcher("javax.xml.stream.XMLInputFactory setProperty(java.lang.String, ..)");
 
@@ -34,6 +41,10 @@ public class XmlParserXXEVulnerability extends Recipe {
     private static final String SUPPORT_DTD_PROPERTY_NAME = "SUPPORT_DTD";
     private static final String XML_PARSER_INITIALIZATION_METHOD = "xml-parser-initialization-method";
     private static final String XML_FACTORY_VARIABLE_NAME = "xml-factory-variable-name";
+
+    public static class ExternalDTDs {
+        Set<String> externalDTDs = new CopyOnWriteArraySet<>();
+    }
 
     @Override
     public String getDisplayName() {
@@ -46,7 +57,35 @@ public class XmlParserXXEVulnerability extends Recipe {
     }
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
+    public ExternalDTDs getInitialValue(ExecutionContext ctx) {
+        return new ExternalDTDs();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(ExternalDTDs acc) {
+
+        return new XmlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.DocTypeDecl visitDocTypeDecl(Xml.DocTypeDecl docTypeDecl, ExecutionContext executionContext) {
+                // Write tests for checking what is included in getExternalSubsets().
+                if (docTypeDecl.getExternalSubsets() != null) {
+                    for (Xml.Element element : docTypeDecl.getExternalSubsets().getElements()) {
+                        for (Xml.Ident ident : element.getSubset()) {
+                            String dtdPath = ident.getName().split("\"")[1];
+                            acc.externalDTDs.add(dtdPath);
+                        }
+                    }
+                }
+                if (!docTypeDecl.getInternalSubset().isEmpty()){
+                    acc.externalDTDs.add(docTypeDecl.getInternalSubset().get(1).getName().replace("\"", ""));
+                }
+                return super.visitDocTypeDecl(docTypeDecl, executionContext);
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(ExternalDTDs acc) {
         return Preconditions.check(new UsesType<>(XML_FACTORY_FQN, true), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
@@ -63,7 +102,13 @@ public class XmlParserXXEVulnerability extends Recipe {
                     setPropertyBlockCursor = supportsExternalCursor == null ? supportsDTDCursor : supportsExternalCursor;
                 }
                 if (setPropertyBlockCursor != null && xmlFactoryVariableName != null) {
-                    doAfterVisit(new XmlFactoryInsertPropertyStatementVisitor(setPropertyBlockCursor.getValue(), xmlFactoryVariableName, supportsExternalCursor == null, supportsDTDCursor == null));
+                    doAfterVisit(new XmlFactoryInsertPropertyStatementVisitor(
+                            setPropertyBlockCursor.getValue(),
+                            xmlFactoryVariableName,
+                            supportsExternalCursor == null,
+                            supportsDTDCursor == null && acc.externalDTDs.isEmpty(),
+                            acc
+                    ));
                 }
                 return cd;
             }
@@ -89,6 +134,15 @@ public class XmlParserXXEVulnerability extends Recipe {
                     } else if (SUPPORT_DTD_PROPERTY_NAME.equals(fa.getSimpleName())) {
                         getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORT_DTD_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
                     }
+                } else if (XML_PARSER_FACTORY_SET_PROPERTY.matches(m) && m.getArguments().get(0) instanceof J.Literal) {
+                    J.Literal literal = (J.Literal) m.getArguments().get(0);
+                    if (TypeUtils.isOfClassType(literal.getType(), "String")) {
+                        if (XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES.equals(literal.getValue())) {
+                            getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
+                        } else if (XMLInputFactory.SUPPORT_DTD.equals(literal.getValue())) {
+                            getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORT_DTD_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
+                        }
+                    }
                 }
                 return m;
             }
@@ -98,15 +152,62 @@ public class XmlParserXXEVulnerability extends Recipe {
     private static class XmlFactoryInsertPropertyStatementVisitor extends JavaIsoVisitor<ExecutionContext> {
         J.Block scope;
         StringBuilder propertyTemplate = new StringBuilder();
+        ExternalDTDs acc;
 
-        public XmlFactoryInsertPropertyStatementVisitor(J.Block scope, String factoryVariableName, boolean needsExternalEntitiesDisabled, boolean needsSupportsDtdDisabled) {
+        public XmlFactoryInsertPropertyStatementVisitor(
+                J.Block scope,
+                String factoryVariableName,
+                boolean needsExternalEntitiesDisabled,
+                boolean needsSupportsDtdDisabled,
+                ExternalDTDs acc
+        ) {
             this.scope = scope;
+            this.acc = acc;
             if (needsExternalEntitiesDisabled) {
                 propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);");
             }
             if (needsSupportsDtdDisabled) {
                 propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, false);");
             }
+            if (!acc.externalDTDs.isEmpty()){
+                propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, true);");
+
+            }
+        }
+
+        private Set<String> addAllowList(){
+            if (acc.externalDTDs.isEmpty()){
+                return Collections.emptySet();
+            }
+            Set<String> imports = new HashSet<>();
+            imports.add("java.util.Collection");
+            imports.add("java.util.Collections");
+            imports.add("javax.xml.stream.XMLStreamException");
+
+            String newAllowListVariableName = VariableNameUtils.generateVariableName(
+                    "allowList",
+                    getCursor(),
+                    VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER
+            );
+            propertyTemplate.append(
+                    "Collection<String>" + newAllowListVariableName + " = Collections.singleton(\n"
+            );
+            String allowListContent = acc.externalDTDs.stream().map(dtd -> '"' + dtd + '"').collect(Collectors.joining(
+                    ",\n\t",
+                    "\t",
+                    ""
+            ));
+            propertyTemplate.append(allowListContent).append("\n);\n");
+            propertyTemplate.append(
+                    "f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {\n" +
+                    "   if (" + newAllowListVariableName + ".contains(systemID)){\n" +
+                    "       return null;\n" +
+                    "   }\n" +
+                    "   throw new XMLStreamException(\"Loading of DTD was blocked to prevent XXE: \" + systemID);\n" +
+                    "});"
+            );
+
+            return imports;
         }
 
         @Override
@@ -132,6 +233,7 @@ public class XmlParserXXEVulnerability extends Recipe {
                         }
                     }
                 }
+                Set<String> imports = addAllowList();
 
                 if (getCursor().getParent() != null && getCursor().getParent().getValue() instanceof J.ClassDeclaration) {
                     propertyTemplate.insert(0, "{\n").append("}");
@@ -139,8 +241,15 @@ public class XmlParserXXEVulnerability extends Recipe {
                 JavaCoordinates insertCoordinates = beforeStatement != null ?
                         beforeStatement.getCoordinates().before() :
                         b.getCoordinates().lastStatement();
-                b = JavaTemplate.builder(propertyTemplate.toString()).contextSensitive().build().apply(
-                        new Cursor(getCursor().getParent(), b), insertCoordinates);
+                b = JavaTemplate
+                        .builder(propertyTemplate.toString())
+                        .imports(imports.toArray(new String[0]))
+                        .contextSensitive()
+                        .build()
+                        .apply(new Cursor(getCursor().getParent(), b), insertCoordinates);
+                if (b != block){
+                    imports.forEach(this::maybeAddImport);
+                }
             }
             return b;
         }

--- a/src/test/java/org/openrewrite/java/security/XmlEntitySplitterTest.java
+++ b/src/test/java/org/openrewrite/java/security/XmlEntitySplitterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.security;
+
+import net.bytebuddy.asm.Advice;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class XmlEntitySplitterTest {
+
+    @ParameterizedTest
+    @MethodSource("provideEntitySplitTestArguments")
+    void testEntitySplit(String initial, String expected){
+        assertEquals(expected, XmlParserXXEVulnerability.extractURLFromEntity(initial));
+    }
+
+    private static Stream<Arguments> provideEntitySplitTestArguments(){
+        return Stream.of(
+                Arguments.of("<!ENTITY open-hatch-public\n" +
+                             "      PUBLIC \"-//Textuality//TEXT Standard open-hatch boilerplate//EN\"\n" +
+                             "      \"http://www.texty.com/boilerplate/OpenHatch.xml\">",
+                        "http://www.texty.com/boilerplate/OpenHatch.xml"),
+                Arguments.of("<!ENTITY hatch-pic\n" +
+                             "      SYSTEM \"../grafix/OpenHatch.gif\"\n" +
+                             "      NDATA gif>",
+                        "../grafix/OpenHatch.gif")
+          );
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/security/XmlParserXXEVulnerabilityTest.java
+++ b/src/test/java/org/openrewrite/java/security/XmlParserXXEVulnerabilityTest.java
@@ -16,11 +16,14 @@
 package org.openrewrite.java.security;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.xml.Assertions.xml;
 
 class XmlParserXXEVulnerabilityTest implements RewriteTest {
     @Override
@@ -39,7 +42,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import java.io.InputStream;
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
-                      XMLInputFactory factory = XMLInputFactory.newFactory();
+                      XMLInputFactory factory = XMLInputFactory.newInstance();
                       factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
                       factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
                       XMLStreamReader reader = factory.createXMLStreamReader(input);
@@ -60,7 +63,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
               public class MyXmlReader {
-                  XMLInputFactory factory = XMLInputFactory.newFactory();
+                  XMLInputFactory factory = XMLInputFactory.newInstance();
                   {
                       factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
                       factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
@@ -86,7 +89,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import java.io.InputStream;
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
-                      XMLInputFactory f = XMLInputFactory.newFactory();
+                      XMLInputFactory f = XMLInputFactory.newInstance();
                       XMLStreamReader reader = f.createXMLStreamReader(input);
                   }
               }
@@ -97,7 +100,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import java.io.InputStream;
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
-                      XMLInputFactory f = XMLInputFactory.newFactory();
+                      XMLInputFactory f = XMLInputFactory.newInstance();
                       f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
                       f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
                       XMLStreamReader reader = f.createXMLStreamReader(input);
@@ -118,7 +121,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               public class MyXmlReader {
                   private XMLInputFactory f;
                   public MyXmlReader() {
-                      f = XMLInputFactory.newFactory();
+                      f = XMLInputFactory.newInstance();
                       f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
                   }
               }
@@ -128,7 +131,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               public class MyXmlReader {
                   private XMLInputFactory f;
                   public MyXmlReader() {
-                      f = XMLInputFactory.newFactory();
+                      f = XMLInputFactory.newInstance();
                       f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
                       f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
                   }
@@ -148,7 +151,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
               public class MyXmlReader {
-                  XMLInputFactory factory = XMLInputFactory.newFactory();
+                  XMLInputFactory factory = XMLInputFactory.newInstance();
                   public void parseXML(InputStream input) {
                       XMLStreamReader reader = factory.createXMLStreamReader(input);
                   }
@@ -159,7 +162,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
               public class MyXmlReader {
-                  XMLInputFactory factory = XMLInputFactory.newFactory();
+                  XMLInputFactory factory = XMLInputFactory.newInstance();
 
                   {
                       factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
@@ -184,7 +187,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
               public class MyXmlReader {
-                  XMLInputFactory factory = XMLInputFactory.newFactory();
+                  XMLInputFactory factory = XMLInputFactory.newInstance();
 
                   {
                       factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
@@ -199,7 +202,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
               public class MyXmlReader {
-                  XMLInputFactory factory = XMLInputFactory.newFactory();
+                  XMLInputFactory factory = XMLInputFactory.newInstance();
 
                   {
                       factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
@@ -224,7 +227,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
               public class MyXmlReader {
-                  XMLInputFactory factory = XMLInputFactory.newFactory();
+                  XMLInputFactory factory = XMLInputFactory.newInstance();
 
                   {
                       factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
@@ -239,7 +242,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
               public class MyXmlReader {
-                  XMLInputFactory factory = XMLInputFactory.newFactory();
+                  XMLInputFactory factory = XMLInputFactory.newInstance();
 
                   {
                       factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
@@ -253,4 +256,338 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void factoryIsNotVulnerableStringLiteral() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+                      f.setProperty("javax.xml.stream.supportDTD", false);
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void factoryIsVulnerableStringLiteralDTD() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty("javax.xml.stream.supportDTD", false);
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+                import javax.xml.stream.XMLInputFactory;
+                import javax.xml.stream.XMLStreamReader;
+                import java.io.InputStream;
+                public class MyXmlReader {
+                    public void parseXML(InputStream input) {
+                        XMLInputFactory f = XMLInputFactory.newInstance();
+                        f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                        f.setProperty("javax.xml.stream.supportDTD", false);
+                        XMLStreamReader reader = f.createXMLStreamReader(input);
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void factoryIsVulnerableStringLiteralExternal() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+                import javax.xml.stream.XMLInputFactory;
+                import javax.xml.stream.XMLStreamReader;
+                import java.io.InputStream;
+                public class MyXmlReader {
+                    public void parseXML(InputStream input) {
+                        XMLInputFactory f = XMLInputFactory.newInstance();
+                        f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                        f.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+                        XMLStreamReader reader = f.createXMLStreamReader(input);
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "<!DOCTYPE note [<!ENTITY note SYSTEM \"http://example.com/note.dtd\">]>",
+      "<!DOCTYPE note SYSTEM \"http://example.com/note.dtd\">",
+    })
+    void factoryIsVulnerableButXMLDocTypesPresent(String docType) {
+        rewriteRun(
+          xml(
+            docType + """
+              <note>
+                <to>Tove</to>
+                <from>Jani</from>
+                <heading>Reminder</heading>
+                <body>Don't forget me this weekend!</body>
+              </note>
+              """
+          ),
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void factoryIsVulnerableButMultipleXMLDocTypesPresent() {
+        rewriteRun(
+          xml(
+            """
+              <!DOCTYPE note [
+              <!ENTITY note SYSTEM "http://example.com/note.dtd">
+              <!ENTITY another SYSTEM "http://example.com/another.dtd">
+              ]>
+              <note>
+                <to>Tove</to>
+                <from>Jani</from>
+                <heading>Reminder</heading>
+                <body>Don't forget me this weekend!</body>
+              </note>
+              """
+          ),
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+    @Test
+    void factoryIsVulnerableButWithInternalXMLDocTypesPresent() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0"?>
+              <!DOCTYPE person>
+              <person>
+                <name>
+                  <first_name>Alan</first_name>
+                  <last_name>Turing</last_name>
+                </name>
+                <profession>computer scientist</profession>
+                <profession>mathematician</profession>
+                <profession>cryptographer</profession>
+              </person>
+              """
+          ),
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void factoryIsVulnerableButWithInternalCheckstyleXMLDocTypesPresent() {
+        rewriteRun(
+          xml(
+            """
+                <!DOCTYPE module PUBLIC
+                    "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                    "https://checkstyle.org/dtds/configuration_1_2.dtd">
+                <module name="Checker">
+                    <module name="DefaultComesLast"/>
+                </module>
+              """
+          ),
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamException;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              import java.util.Collection;
+              import java.util.Collections;
+              
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                      Collection<String> allowList = Collections.singleton(
+                              "https://checkstyle.org/dtds/configuration_1_2.dtd"
+                      );
+                      f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                          if (allowList.contains(systemID)) {
+                              return null;
+                          }
+                          throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
+                      });
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void testInternalSubsets() {
+        rewriteRun(
+          xml(
+            """
+              <!DOCTYPE GAME PUBLIC "Game.dtd">
+              <GAME>
+                  <team1>SA</team1>
+                  <team2>UK</team2>
+                  <score>2-0</score>
+              </GAME>
+              """
+          ),
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                      Collection<String> allowList = Collections.singleton(
+                              "Game.dtd"
+                      );
+                      f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                          if (allowList.contains(systemID)){
+                              return null;
+                          }
+                          throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
+                      });
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/src/test/java/org/openrewrite/java/security/XmlParserXXEVulnerabilityTest.java
+++ b/src/test/java/org/openrewrite/java/security/XmlParserXXEVulnerabilityTest.java
@@ -713,10 +713,10 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
                   <!ENTITY hatch-pic
                     SYSTEM "../grafix/OpenHatch.gif"
                     NDATA gif>
-                ]>
-                <root>
-                  <!-- Your XML content here -->
-                </root>
+              ]>
+              <root>
+                <!-- Your XML content here -->
+              </root>
               """
           ),
           java(
@@ -726,8 +726,8 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import java.io.InputStream;
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
-                      XMLInputFactory f = XMLInputFactory.newInstance();
-                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                      XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+                      XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(input);
                   }
               }
               """,
@@ -741,22 +741,22 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
-                      XMLInputFactory f = XMLInputFactory.newInstance();
-                      f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-                      f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                      XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+                      xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                      xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, true);
                       Collection<String> allowList = Arrays.asList(
                               "http://www.textuality.com/boilerplate/OpenHatch.xml",
                               "http://www.texty.com/boilerplate/OpenHatch.xml",
                               "../grafix/OpenHatch.gif"
                       );
-                      f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                      xmlInputFactory.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
                           if (allowList.contains(systemID)) {
                               // returning null will cause the parser to resolve the entity
                               return null;
                           }
                           throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
                       });
-                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                      XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(input);
                   }
               }
               """
@@ -784,8 +784,8 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
                           import java.io.InputStream;
                           public class MyXmlReader {
                               public void parseXML(InputStream input) {
-                                  XMLInputFactory f = XMLInputFactory.newInstance();
-                                  XMLStreamReader reader = f.createXMLStreamReader(input);
+                                  XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+                                  XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(input);
                               }
                           }
                           """,
@@ -799,20 +799,20 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
                           
                           public class MyXmlReader {
                               public void parseXML(InputStream input) {
-                                  XMLInputFactory f = XMLInputFactory.newInstance();
-                                  f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-                                  f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                                  XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+                                  xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                                  xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, true);
                                   Collection<String> allowList = Collections.singleton(
                                           "example.dtd"
                                   );
-                                  f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                                  xmlInputFactory.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
                                       if (allowList.contains(systemID)) {
                                           // returning null will cause the parser to resolve the entity
                                           return null;
                                       }
                                       throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
                                   });
-                                  XMLStreamReader reader = f.createXMLStreamReader(input);
+                                  XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(input);
                               }
                           }
                           """

--- a/src/test/java/org/openrewrite/java/security/XmlParserXXEVulnerabilityTest.java
+++ b/src/test/java/org/openrewrite/java/security/XmlParserXXEVulnerabilityTest.java
@@ -394,6 +394,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
                       );
                       f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
                           if (allowList.contains(systemID)) {
+                              // returning null will cause the parser to resolve the entity
                               return null;
                           }
                           throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
@@ -454,6 +455,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
                       );
                       f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
                           if (allowList.contains(systemID)) {
+                              // returning null will cause the parser to resolve the entity
                               return null;
                           }
                           throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
@@ -555,6 +557,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
                       );
                       f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
                           if (allowList.contains(systemID)) {
+                              // returning null will cause the parser to resolve the entity
                               return null;
                           }
                           throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
@@ -572,7 +575,9 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
         rewriteRun(
           xml(
             """
-              <!DOCTYPE GAME PUBLIC "Game.dtd">
+              <!DOCTYPE GAME PUBLIC 
+                   "PublicGameIdentifier"
+                   "Game.dtd">
               <GAME>
                   <team1>SA</team1>
                   <team2>UK</team2>
@@ -594,17 +599,23 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               """,
             """
               import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamException;
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
+              import java.util.Collection;
+              import java.util.Collections;
+              
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
                       XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
                       f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
                       Collection<String> allowList = Collections.singleton(
                               "Game.dtd"
                       );
                       f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
-                          if (allowList.contains(systemID)){
+                          if (allowList.contains(systemID)) {
+                              // returning null will cause the parser to resolve the entity
                               return null;
                           }
                           throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
@@ -648,6 +659,7 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
                       );
                       f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
                           if (allowList.contains(systemID)){
+                              // returning null will cause the parser to resolve the entity
                               return null;
                           }
                           throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
@@ -667,12 +679,14 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               public class MyXmlReader {
                   public void parseXML(InputStream input) throws XMLStreamException {
                       XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
                       f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
                       Collection<String> allowList = Collections.singleton(
                               "Game.dtd"
                       );
                       f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
                           if (allowList.contains(systemID)){
+                              // returning null will cause the parser to resolve the entity
                               return null;
                           }
                           throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
@@ -684,5 +698,127 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void factoryIsVulnerableWithPublicAndSystemIdPresent() {
+        rewriteRun(
+          xml(
+            """
+              <!DOCTYPE xml [
+                  <!ENTITY open-hatch-system
+                    SYSTEM "http://www.textuality.com/boilerplate/OpenHatch.xml">
+                  <!ENTITY open-hatch-public
+                    PUBLIC "-//Textuality//TEXT Standard open-hatch boilerplate//EN"
+                    "http://www.texty.com/boilerplate/OpenHatch.xml">
+                  <!ENTITY hatch-pic
+                    SYSTEM "../grafix/OpenHatch.gif"
+                    NDATA gif>
+                ]>
+                <root>
+                  <!-- Your XML content here -->
+                </root>
+              """
+          ),
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamException;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              import java.util.Arrays;
+              import java.util.Collection;
+              
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                      Collection<String> allowList = Arrays.asList(
+                              "http://www.textuality.com/boilerplate/OpenHatch.xml",
+                              "http://www.texty.com/boilerplate/OpenHatch.xml",
+                              "../grafix/OpenHatch.gif"
+                      );
+                      f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                          if (allowList.contains(systemID)) {
+                              // returning null will cause the parser to resolve the entity
+                              return null;
+                          }
+                          throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
+                      });
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void factoryHasSystemDoctypeEntities() {
+        rewriteRun(
+                xml(
+                        """
+                          <?xml version="1.0" encoding="UTF-8"?>
+                          <!DOCTYPE root SYSTEM "example.dtd">
+                          <root>
+                            <element1>Value 1</element1>
+                            <element2>Value 2</element2>
+                          </root>
+                          """
+                ),
+                java(
+                        """
+                          import javax.xml.stream.XMLInputFactory;
+                          import javax.xml.stream.XMLStreamReader;
+                          import java.io.InputStream;
+                          public class MyXmlReader {
+                              public void parseXML(InputStream input) {
+                                  XMLInputFactory f = XMLInputFactory.newInstance();
+                                  XMLStreamReader reader = f.createXMLStreamReader(input);
+                              }
+                          }
+                          """,
+                        """
+                          import javax.xml.stream.XMLInputFactory;
+                          import javax.xml.stream.XMLStreamException;
+                          import javax.xml.stream.XMLStreamReader;
+                          import java.io.InputStream;
+                          import java.util.Collection;
+                          import java.util.Collections;
+                          
+                          public class MyXmlReader {
+                              public void parseXML(InputStream input) {
+                                  XMLInputFactory f = XMLInputFactory.newInstance();
+                                  f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                                  f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                                  Collection<String> allowList = Collections.singleton(
+                                          "example.dtd"
+                                  );
+                                  f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                                      if (allowList.contains(systemID)) {
+                                          // returning null will cause the parser to resolve the entity
+                                          return null;
+                                      }
+                                      throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
+                                  });
+                                  XMLStreamReader reader = f.createXMLStreamReader(input);
+                              }
+                          }
+                          """
+                )
+        );
+    }
+
 
 }

--- a/src/test/java/org/openrewrite/java/security/XmlParserXXEVulnerabilityTest.java
+++ b/src/test/java/org/openrewrite/java/security/XmlParserXXEVulnerabilityTest.java
@@ -378,13 +378,26 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               """,
             """
               import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamException;
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
+              import java.util.Collection;
+              import java.util.Collections;
+              
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
                       XMLInputFactory f = XMLInputFactory.newInstance();
                       f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-                      f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                      Collection<String> allowList = Collections.singleton(
+                              "http://example.com/note.dtd"
+                      );
+                      f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                          if (allowList.contains(systemID)) {
+                              return null;
+                          }
+                          throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
+                      });
                       XMLStreamReader reader = f.createXMLStreamReader(input);
                   }
               }
@@ -424,13 +437,27 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               """,
             """
               import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamException;
               import javax.xml.stream.XMLStreamReader;
               import java.io.InputStream;
+              import java.util.Arrays;
+              import java.util.Collection;
+              
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
                       XMLInputFactory f = XMLInputFactory.newInstance();
                       f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-                      f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                      Collection<String> allowList = Arrays.asList(
+                              "http://example.com/note.dtd",
+                              "http://example.com/another.dtd"
+                      );
+                      f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                          if (allowList.contains(systemID)) {
+                              return null;
+                          }
+                          throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
+                      });
                       XMLStreamReader reader = f.createXMLStreamReader(input);
                   }
               }
@@ -571,6 +598,74 @@ class XmlParserXXEVulnerabilityTest implements RewriteTest {
               import java.io.InputStream;
               public class MyXmlReader {
                   public void parseXML(InputStream input) {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                      Collection<String> allowList = Collections.singleton(
+                              "Game.dtd"
+                      );
+                      f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                          if (allowList.contains(systemID)){
+                              return null;
+                          }
+                          throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
+                      });
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void factoryIsNotVulnerableButAllowListPresent() {
+        rewriteRun(
+          xml(
+            """
+              <!DOCTYPE GAME PUBLIC "Game.dtd">
+              <GAME>
+                  <team1>SA</team1>
+                  <team2>UK</team2>
+                  <score>2-0</score>
+              </GAME>
+              """
+          ),
+          java(
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamException;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              import java.util.Collection;
+              import java.util.Collections;
+              
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) throws XMLStreamException {
+                      XMLInputFactory f = XMLInputFactory.newInstance();
+                      f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+                      Collection<String> allowList = Collections.singleton(
+                              "Game.dtd"
+                      );
+                      f.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+                          if (allowList.contains(systemID)){
+                              return null;
+                          }
+                          throw new XMLStreamException("Loading of DTD was blocked to prevent XXE: " + systemID);
+                      });
+                      XMLStreamReader reader = f.createXMLStreamReader(input);
+                  }
+              }
+              """,
+            """
+              import javax.xml.stream.XMLInputFactory;
+              import javax.xml.stream.XMLStreamException;
+              import javax.xml.stream.XMLStreamReader;
+              import java.io.InputStream;
+              import java.util.Collection;
+              import java.util.Collections;
+              
+              public class MyXmlReader {
+                  public void parseXML(InputStream input) throws XMLStreamException {
                       XMLInputFactory f = XMLInputFactory.newInstance();
                       f.setProperty(XMLInputFactory.SUPPORT_DTD, true);
                       Collection<String> allowList = Collections.singleton(


### PR DESCRIPTION
- Improved XXE Recipe
- Added basic functionality for allow-list with multiple DTDs. Testing needed
- Added support for allowlist generation for SYSTEM and PUBLIC Identifiers
- Fixed issues with generation of duplicate allow-lists
