### PR TITLE
fix: adapt J.Identifier instantiation to use the new constructor

### DIFF
--- a/src/main/java/org/openrewrite/java/security/ZipSlip.java
+++ b/src/main/java/org/openrewrite/java/security/ZipSlip.java
@@ -39,6 +39,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static java.util.Collections.emptyList;
+
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class ZipSlip extends Recipe {
@@ -415,6 +417,7 @@ public class ZipSlip extends Recipe {
                                 Tree.randomId(),
                                 Space.EMPTY,
                                 Markers.EMPTY,
+                                emptyList(),
                                 newVariableName,
                                 methodCall.getType(),
                                 null


### PR DESCRIPTION
…onstructor

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Switched J.Identifier instantiation to use the new constructor to resolve the build issues.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
To resolve the build issues

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
no

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
