### PR TITLE
Remove unnecessary argument in updateBlock

### DIFF
--- a/src/main/java/org/openrewrite/java/security/xml/TransformerFactoryInsertAttributeStatementVisitor.java
+++ b/src/main/java/org/openrewrite/java/security/xml/TransformerFactoryInsertAttributeStatementVisitor.java
@@ -51,7 +51,7 @@ public class TransformerFactoryInsertAttributeStatementVisitor<P> extends XmlFac
         J.Block b = super.visitBlock(block, ctx);
         Statement beforeStatement = getInsertStatement(b);
         if (b.isScope(getScope())) {
-            b = updateBlock(b, block, beforeStatement, Collections.singleton("javax.xml.XMLConstants"));
+            b = updateBlock(b, beforeStatement, Collections.singleton("javax.xml.XMLConstants"));
         }
         return b;
     }

--- a/src/main/java/org/openrewrite/java/security/xml/XmlFactoryInsertPropertyStatementVisitor.java
+++ b/src/main/java/org/openrewrite/java/security/xml/XmlFactoryInsertPropertyStatementVisitor.java
@@ -117,7 +117,7 @@ class XmlFactoryInsertPropertyStatementVisitor<P> extends XmlFactoryInsertVisito
         Statement beforeStatement = getInsertStatement(b);
         if (b.isScope(getScope())) {
             Set<String> imports = addAllowList(generateAllowList);
-            b = updateBlock(b, block, beforeStatement, imports);
+            b = updateBlock(b, beforeStatement, imports);
         }
         return b;
     }

--- a/src/main/java/org/openrewrite/java/security/xml/XmlFactoryInsertVisitor.java
+++ b/src/main/java/org/openrewrite/java/security/xml/XmlFactoryInsertVisitor.java
@@ -65,7 +65,7 @@ public abstract class XmlFactoryInsertVisitor<P> extends JavaIsoVisitor<P> {
         return s != null ? s.getCoordinates().before() : b.getCoordinates().lastStatement();
     }
 
-    public J.Block updateBlock(J.Block b, J.Block block, Statement beforeStatement, Set<String> imports) {
+    public J.Block updateBlock(J.Block b, Statement beforeStatement, Set<String> imports) {
         if (getCursor().getParent() != null && getCursor().getParent().getValue() instanceof J.ClassDeclaration) {
             template.insert(0, "{\n").append("}");
         }
@@ -75,9 +75,7 @@ public abstract class XmlFactoryInsertVisitor<P> extends JavaIsoVisitor<P> {
                 .contextSensitive()
                 .build()
                 .apply(new Cursor(getCursor().getParent(), b), getInsertCoordinates(b, beforeStatement));
-        if (b != block) {
-            imports.forEach(this::maybeAddImport);
-        }
+        imports.forEach(this::maybeAddImport);
         return b;
     }
 }


### PR DESCRIPTION
- Removal of the `block` parameter inside `updateBlock`