### PR TITLE
Add missing import in XmlParserXXEVulnerability

### DIFF
--- a/src/main/java/org/openrewrite/java/security/xml/DBFInsertPropertyStatementVisitor.java
+++ b/src/main/java/org/openrewrite/java/security/xml/DBFInsertPropertyStatementVisitor.java
@@ -17,11 +17,13 @@ package org.openrewrite.java.security.xml;
 
 import org.openrewrite.java.tree.J;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public class DBFInsertPropertyStatementVisitor<P> extends XmlFactoryInsertVisitor<P> {
-    private static final Set<String> IMPORTS = Collections.singleton("javax.xml.parsers.ParserConfigurationException");
+    private static final Set<String> IMPORTS = new HashSet<>(Arrays.asList("javax.xml.parsers.ParserConfigurationException", "javax.xml.XMLConstants"));
 
     private final boolean disallowDoctypes;
     private final boolean disallowGeneralEntities;


### PR DESCRIPTION
The conditional part of the template starting in lines 105ff. needs XmlConstants as import.

Fixes #107.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases

Trying to create a unit test from my real life example didn't work in this case for unknown reasons. I never managed to trigger the conditional template part in my reproducer.