### PR TITLE
Fix broken cross reference for Owasp A10 (#111)

### DIFF
--- a/src/main/resources/META-INF/rewrite/owasp.yml
+++ b/src/main/resources/META-INF/rewrite/owasp.yml
@@ -28,7 +28,7 @@ recipeList:
   - org.openrewrite.java.security.OwaspA05
   - org.openrewrite.java.security.OwaspA06
   - org.openrewrite.java.security.OwaspA08
-  - org.openrewrite.java.security.OwaspA010
+  - org.openrewrite.java.security.OwaspA10
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.security.OwaspA01


### PR DESCRIPTION
## What's changed?
Recipe validation no longer fails for `org.openrewrite.java.security.OwaspTopTen`.

## What's your motivation?
#111

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
