### PR TITLE
POC: `@NestedOptions` use case for Security Recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java
+++ b/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java
@@ -15,17 +15,19 @@
  */
 package org.openrewrite.java.security;
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.security.sourcefilter.SourceFilterOptions;
+import org.openrewrite.java.security.sourcefilter.SourceFilterRecipe;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 
@@ -34,7 +36,7 @@ import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
-public class SecureTempFileCreation extends Recipe {
+public class SecureTempFileCreation extends SourceFilterRecipe {
 
     @Override
     public String getDisplayName() {
@@ -46,8 +48,12 @@ public class SecureTempFileCreation extends Recipe {
         return "`java.io.File.createTempFile()` has exploitable default file permissions. This recipe migrates to the more secure `java.nio.file.Files.createTempFile()`.";
     }
 
+    //@NestedOptions
+    @JsonUnwrapped
+    SourceFilterOptions securityRecipeOptions;
+
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
+    public TreeVisitor<?, ExecutionContext> getSourceFilteredVisitor() {
         return Preconditions.check(new UsesMethod<>(SecureTempFileCreationVisitor.MATCHER), new SecureTempFileCreationVisitor());
     }
 

--- a/src/main/java/org/openrewrite/java/security/sourcefilter/SourceFilterOptions.java
+++ b/src/main/java/org/openrewrite/java/security/sourcefilter/SourceFilterOptions.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.security.sourcefilter;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.search.IsLikelyNotTest;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+@Value
+public class SourceFilterOptions {
+    public enum SourceFilter {
+        ALL,
+        ALL_WHEN_NON_TEST,
+        NON_TEST
+    }
+
+    @Option(
+            displayName = "Source Filter",
+            description = "The source sets to apply this recipe to. \n" +
+                          " - `ALL`: Apply to all source sets.\n" +
+                          " - `ALL-WHEN-NON-TEST`: Only when the recipe changes non-test code, also apply it to test code. " +
+                          "IE. Only apply this recipe to all source files, when a non-test file will be modified.\n" +
+                          " - `NON-TEST`: Apply only to non-test code.",
+            valid = {"ALL", "ALL-WHEN-NON-TEST", "NON-TEST"},
+            example = "ALL",
+            required = false
+    )
+    SourceFilter sourceFilter;
+
+    public SourceFilter getSourceFilter() {
+        //noinspection ConstantValue
+        if (sourceFilter == null) {
+            return SourceFilter.ALL;
+        }
+        return sourceFilter;
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PACKAGE, staticName = "create")
+    public static class Accumulator {
+        private final SourceFilterOptions options;
+        private final AtomicBoolean hasNonTestModifications = new AtomicBoolean(false);
+
+        TreeVisitor<?, ExecutionContext> scanner(Supplier<TreeVisitor<?, ExecutionContext>> visitor) {
+            switch (options.getSourceFilter()) {
+                case ALL:
+                case NON_TEST:
+                    return TreeVisitor.noop();
+                case ALL_WHEN_NON_TEST:
+                    return new TreeVisitor<Tree, ExecutionContext>() {
+                        @Override
+                        public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                            if (!hasNonTestModifications.get()
+                                && new IsLikelyNotTest().getVisitor().visit(tree, ctx) != tree
+                                && visitor.get().visit(tree, ctx) != tree) {
+                                hasNonTestModifications.set(true);
+                            }
+                            return tree;
+                        }
+                    };
+                default:
+                    throw new IllegalStateException("Unsupported source filter " + options.getSourceFilter());
+            }
+        }
+
+        TreeVisitor<?, ExecutionContext> getVisitor(Supplier<TreeVisitor<?, ExecutionContext>> visitor) {
+            switch (options.getSourceFilter()) {
+                case ALL:
+                    return visitor.get();
+                case ALL_WHEN_NON_TEST:
+                    if (hasNonTestModifications.get()) {
+                        return visitor.get();
+                    } else {
+                        return TreeVisitor.noop();
+                    }
+                case NON_TEST:
+                    Preconditions.check(new IsLikelyNotTest(), visitor.get());
+                default:
+                    throw new IllegalStateException("Unsupported source filter " + options.getSourceFilter());
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/security/sourcefilter/SourceFilterRecipe.java
+++ b/src/main/java/org/openrewrite/java/security/sourcefilter/SourceFilterRecipe.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.security.sourcefilter;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.TreeVisitor;
+
+public abstract class SourceFilterRecipe extends ScanningRecipe<SourceFilterOptions.Accumulator> {
+
+    public abstract SourceFilterOptions getSecurityRecipeOptions();
+
+    @Override
+    public SourceFilterOptions.Accumulator getInitialValue(ExecutionContext ctx) {
+        return SourceFilterOptions.Accumulator.create(getSecurityRecipeOptions());
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(SourceFilterOptions.Accumulator acc) {
+        return acc.scanner(this::getSourceFilteredVisitor);
+    }
+
+    @Override
+    public final TreeVisitor<?, ExecutionContext> getVisitor(SourceFilterOptions.Accumulator acc) {
+        return acc.getVisitor(this::getSourceFilteredVisitor);
+    }
+
+    public abstract TreeVisitor<?, ExecutionContext> getSourceFilteredVisitor();
+
+}

--- a/src/main/java/org/openrewrite/java/security/sourcefilter/package-info.java
+++ b/src/main/java/org/openrewrite/java/security/sourcefilter/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.openrewrite.java.security.sourcefilter;
+
+import org.openrewrite.internal.lang.NonNullApi;

--- a/src/test/java/org/openrewrite/java/security/SecureTempFileCreationFilteringTest.java
+++ b/src/test/java/org/openrewrite/java/security/SecureTempFileCreationFilteringTest.java
@@ -17,16 +17,9 @@ package org.openrewrite.java.security;
 
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.ScanningRecipe;
-import org.openrewrite.Tree;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.search.IsLikelyNotTest;
+import org.openrewrite.java.security.sourcefilter.SourceFilterOptions;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.openrewrite.java.Assertions.*;
 
@@ -98,7 +91,7 @@ public class SecureTempFileCreationFilteringTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new FilteringSecureTempFileCreation());
+        spec.recipe(new SecureTempFileCreation(new SourceFilterOptions(SourceFilterOptions.SourceFilter.ALL_WHEN_NON_TEST)));
     }
 
     @Test
@@ -141,43 +134,5 @@ public class SecureTempFileCreationFilteringTest implements RewriteTest {
             java(TEST_VULNERABLE)
           )
         );
-    }
-
-    public static class FilteringSecureTempFileCreation extends ScanningRecipe<AtomicBoolean> {
-
-        @Override
-        public String getDisplayName() {
-            return "SecureTempFileCreation with filtering";
-        }
-
-        @Override
-        public String getDescription() {
-            return "Applies `SecureTempFileCreation` using `IsLikelyNotTest` and `SecureTempFileCreation` as applicability tests.";
-        }
-
-        @Override
-        public AtomicBoolean getInitialValue(ExecutionContext ctx) {
-            return new AtomicBoolean(false);
-        }
-
-        @Override
-        public TreeVisitor<?, ExecutionContext> getScanner(AtomicBoolean acc) {
-            return new TreeVisitor<>() {
-                @Override
-                public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                    if (!acc.get()
-                      && new IsLikelyNotTest().getVisitor().visit(tree, ctx) != tree
-                      && new SecureTempFileCreation().getVisitor().visit(tree, ctx) != tree) {
-                        acc.set(true);
-                    }
-                    return tree;
-                }
-            };
-        }
-
-        @Override
-        public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean acc) {
-            return acc.get() ? new SecureTempFileCreation().getVisitor() : TreeVisitor.noop();
-        }
     }
 }

--- a/src/test/java/org/openrewrite/java/security/SecureTempFileCreationTest.java
+++ b/src/test/java/org/openrewrite/java/security/SecureTempFileCreationTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.security;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
+import org.openrewrite.java.security.sourcefilter.SourceFilterOptions;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -27,7 +28,7 @@ class SecureTempFileCreationTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new SecureTempFileCreation());
+        spec.recipe(new SecureTempFileCreation(new SourceFilterOptions(SourceFilterOptions.SourceFilter.ALL)));
     }
 
     @DocumentExample


### PR DESCRIPTION
Demonstrates how `@NestedOptions` would be used for Security Recipes.

This allows for filtering the application of Recipes so they are only applied to tests when non-tests are modified.

To be compatible with the Moderne SaaS, this will require 
- https://github.com/openrewrite/rewrite/pull/3764 to be merged

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
