### PR TITLE
General Cleanup & Improvements

### DIFF
--- a/src/main/java/org/openrewrite/java/security/FixCwe338.java
+++ b/src/main/java/org/openrewrite/java/security/FixCwe338.java
@@ -25,7 +25,9 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -41,6 +43,11 @@ public class FixCwe338 extends Recipe {
     @Override
     public String getDescription() {
         return "Use a cryptographically strong pseudo-random number generator (PRNG).";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("CWE-338");
     }
 
     private JavaParser.Builder<?, ?> javaParser() {

--- a/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java
+++ b/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java
@@ -29,7 +29,10 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 
+import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 
 @Value
@@ -44,6 +47,16 @@ public class SecureTempFileCreation extends Recipe {
     @Override
     public String getDescription() {
         return "`java.io.File.createTempFile()` has exploitable default file permissions. This recipe migrates to the more secure `java.nio.file.Files.createTempFile()`.";
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("CWE-377");
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/security/UseFilesCreateTempDirectory.java
+++ b/src/main/java/org/openrewrite/java/security/UseFilesCreateTempDirectory.java
@@ -50,7 +50,7 @@ public class UseFilesCreateTempDirectory extends Recipe {
 
     @Override
     public Set<String> getTags() {
-        return Collections.singleton("RSPEC-5445");
+        return new HashSet<>(Arrays.asList("RSPEC-5445", "CWE-379", "CWE-377"));
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
+++ b/src/main/java/org/openrewrite/java/security/XmlParserXXEVulnerability.java
@@ -23,7 +23,9 @@ import org.openrewrite.java.security.xml.TransformerFactoryFixVisitor;
 import org.openrewrite.java.security.xml.XmlInputFactoryFixVisitor;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class XmlParserXXEVulnerability extends ScanningRecipe<ExternalDTDAccumulator> {
 
@@ -35,6 +37,11 @@ public class XmlParserXXEVulnerability extends ScanningRecipe<ExternalDTDAccumul
     @Override
     public String getDescription() {
         return "Avoid exposing dangerous features of the XML parser by updating certain factory settings.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("CWE-611");
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/security/marshalling/SecureJacksonDefaultTyping.java
+++ b/src/main/java/org/openrewrite/java/security/marshalling/SecureJacksonDefaultTyping.java
@@ -19,6 +19,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
@@ -27,6 +28,11 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 
@@ -40,6 +46,16 @@ public class SecureJacksonDefaultTyping extends Recipe {
     @Override
     public String getDescription() {
         return "See the [blog post](https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062) on this subject.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(10);
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return new HashSet<>(Arrays.asList("CWE-502", "CWE-94"));
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/security/marshalling/SecureSnakeYamlConstructor.java
+++ b/src/main/java/org/openrewrite/java/security/marshalling/SecureSnakeYamlConstructor.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
@@ -44,6 +45,11 @@ public class SecureSnakeYamlConstructor extends Recipe {
     @Override
     public String getDescription() {
         return "See the [paper](https://github.com/mbechler/marshalsec) on this subject.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return new HashSet<>(Arrays.asList("CWE-502", "CWE-94"));
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/security/servlet/CookieSetSecure.java
+++ b/src/main/java/org/openrewrite/java/security/servlet/CookieSetSecure.java
@@ -28,6 +28,9 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class CookieSetSecure extends Recipe {
 
     @Override
@@ -39,6 +42,11 @@ public class CookieSetSecure extends Recipe {
     public String getDescription() {
         return "Check for use of insecure cookies. Cookies should be marked as secure. " +
                "This ensures that the cookie is sent only over HTTPS to prevent cross-site scripting attacks.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("CWE-614");
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/security/spring/CsrfProtection.java
+++ b/src/main/java/org/openrewrite/java/security/spring/CsrfProtection.java
@@ -25,6 +25,8 @@ import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -44,6 +46,11 @@ public class CsrfProtection extends ScanningRecipe<GenerateWebSecurityConfigurer
     @Override
     public String getDescription() {
         return "Cross-Site Request Forgery (CSRF) is a type of attack that occurs when a malicious web site, email, blog, instant message, or program causes a user's web browser to perform an unwanted action on a trusted site when the user is authenticated. See the full [OWASP cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("CWE-352");
     }
 
     static final MethodMatcher CSRF = new MethodMatcher("org.springframework.security.config.annotation.web.builders.HttpSecurity csrf()");

--- a/src/main/java/org/openrewrite/java/security/spring/PreventClickjacking.java
+++ b/src/main/java/org/openrewrite/java/security/spring/PreventClickjacking.java
@@ -25,7 +25,10 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 
+import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
 
 import static org.openrewrite.java.security.spring.GenerateWebSecurityConfigurerAdapter.WEB_SECURITY_CONFIGURER_ADAPTER;
 
@@ -47,6 +50,16 @@ public class PreventClickjacking extends ScanningRecipe<GenerateWebSecurityConfi
     @Override
     public String getDescription() {
         return "The `frame-ancestors` directive can be used in a Content-Security-Policy HTTP response header to indicate whether or not a browser should be allowed to render a page in a `<frame>` or `<iframe>`. Sites can use this to avoid Clickjacking attacks by ensuring that their content is not embedded into other sites.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("CWE-1021");
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(10);
     }
 
     private static final MethodMatcher FRAME_OPTIONS = new MethodMatcher("org.springframework.security.config.annotation.web.configurers.HeadersConfigurer frameOptions()");

--- a/src/main/resources/META-INF/rewrite/owasp.yml
+++ b/src/main/resources/META-INF/rewrite/owasp.yml
@@ -17,24 +17,22 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.security.OwaspTopTen
 displayName: Remediate vulnerabilities from the OWASP Top Ten
-description: > 
-  [OWASP](https://owasp.org) publishes a list of the most impactful common security vulnerabilities. 
+description: >
+  [OWASP](https://owasp.org) publishes a list of the most impactful common security vulnerabilities.
   These recipes identify and remediate vulnerabilities from the OWASP Top Ten.
 recipeList:
   - org.openrewrite.java.security.OwaspA01
   - org.openrewrite.java.security.OwaspA02
   - org.openrewrite.java.security.OwaspA03
-  - org.openrewrite.java.security.OwaspA04
   - org.openrewrite.java.security.OwaspA05
   - org.openrewrite.java.security.OwaspA06
   - org.openrewrite.java.security.OwaspA08
-  - org.openrewrite.java.security.OwaspA10
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.security.OwaspA01
 displayName: Remediate OWASP A01:2021 Broken access control
 description: >
-  OWASP [A01:2021](https://owasp.org/Top10/A01_2021-Broken_Access_Control/) describes failures related to broken access 
+  OWASP [A01:2021](https://owasp.org/Top10/A01_2021-Broken_Access_Control/) describes failures related to broken access
   control.
 recipeList:
   - org.openrewrite.java.spring.security5.search.FindEncryptorsQueryableTextUses
@@ -45,7 +43,7 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.security.OwaspA02
 displayName: Remediate OWASP A02:2021 Cryptographic failures
 description: >
-  OWASP [A02:2021](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/) describes failures related to cryptography 
+  OWASP [A02:2021](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/) describes failures related to cryptography
   (or lack thereof), which often lead to exposure of sensitive data. This recipe seeks to remediate these vulnerabilities.
 recipeList:
   - org.openrewrite.java.spring.security5.search.FindEncryptorsQueryableTextUses
@@ -63,20 +61,10 @@ recipeList:
   - org.openrewrite.java.security.servlet.CookieSetSecure
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.security.OwaspA04
-displayName: Remediate OWASP A04:2021 Insecure design
-description: >
-  OWASP [A04:2021](https://owasp.org/Top10/A04_2021-Insecure_Design/) focuses on risks related to design and architectural flaws, 
-  with a call for more use of threat modeling, secure design patterns, and reference architectures.
-  This recipe seeks to remediate these vulnerabilities.
-recipeList:
-  - org.openrewrite.java.security.ImproperPrivilegeManagement
----
-type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.security.OwaspA05
 displayName: Remediate OWASP A05:2021 Security misconfiguration
 description: >
-  OWASP [A05:2021](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/) describes failures related to security 
+  OWASP [A05:2021](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/) describes failures related to security
   misconfiguration.
 recipeList:
   - org.openrewrite.java.security.XmlParserXXEVulnerability
@@ -85,7 +73,7 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.security.OwaspA06
 displayName: Remediate OWASP A06:2021 Vulnerable and outdated components
 description: >
-  OWASP [A06:2021](https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/) describes failures related to 
+  OWASP [A06:2021](https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/) describes failures related to
   vulnerable and outdated components.
 recipeList:
   - org.openrewrite.java.dependencies.DependencyVulnerabilityCheck
@@ -94,7 +82,7 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.security.OwaspA08
 displayName: Remediate OWASP A08:2021 Software and data integrity failures
 description: >
-  OWASP [A08:2021](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/) software and data integrity 
+  OWASP [A08:2021](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/) software and data integrity
   failures.
 recipeList:
   - org.openrewrite.java.security.marshalling.InsecureJmsDeserialization
@@ -105,11 +93,4 @@ recipeList:
   - org.openrewrite.java.security.SecureTempFileCreation
   - org.openrewrite.java.security.FindTextDirectionChanges
   - org.openrewrite.java.security.UseFilesCreateTempDirectory
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.security.OwaspA10
-displayName: Remediate OWASP A10:2021 Server-side request forgery (SSRF)
-description: >
-  OWASP [A10:2021](https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/) Server-Side Request Forgery (SSRF)
-recipeList:
   - org.openrewrite.java.security.spring.CsrfProtection

--- a/src/main/resources/META-INF/rewrite/security-bugs.yml
+++ b/src/main/resources/META-INF/rewrite/security-bugs.yml
@@ -24,4 +24,5 @@ recipeList:
   - org.openrewrite.java.security.XmlParserXXEVulnerability
   - org.openrewrite.java.security.UseFilesCreateTempDirectory
   - org.openrewrite.java.security.SecureTempFileCreation
+  - org.openrewrite.java.security.ZipSlip
   - org.openrewrite.staticanalysis.NoEqualityInForCondition


### PR DESCRIPTION
 - Adds several missing CWE tags
 - Adds some missing duration estimates
 - Removes no-op `ImproperPrivilegeManagement` from `owasp`
 - Adds ZipSlip to `JavaSecurityBestPractices`
 - Closes #113

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

See above

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

The OWASP recipe had some problems, miss-labeling, and the inclusion of a recipe that doesn't actually fix the vulnerability.

Also, there were several recipes missing CWE's

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

Do the duration estimates make sense? Is it fine that I removed those recipes from the OWASP one.

## Anyone you would like to review specifically?
<!-- @mention them here -->

@jkschneider

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
