### PR TITLE
Remove nonexistent recipe from yaml

### DIFF
--- a/src/main/resources/META-INF/rewrite/owasp.yml
+++ b/src/main/resources/META-INF/rewrite/owasp.yml
@@ -38,7 +38,6 @@ recipeList:
   - org.openrewrite.java.spring.security5.search.FindEncryptorsQueryableTextUses
   - org.openrewrite.java.security.ZipSlip
   - org.openrewrite.java.security.PartialPathTraversalVulnerability
-  - org.openrewrite.java.security.spring.UnvalidatedRedirect
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.security.OwaspA02


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Removes nonexistent recipe from yaml recipe list.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes #127.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@jkschneider created commit 894f757b9e23eb0e0a50444cd13ed2874017409e and might know best.

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
Instead of removing the line, we could have changed it to the new recipe that was introduced within the same commit. But for me that recipe doesn't fit the Owasp category description.

It would be good to have a more general fix that actually verifies that all yaml recipes contain only valid references to existing recipes in the same jar. I think there was a previous issue where the Owasp list also contained a broken reference.